### PR TITLE
[#2] Build generic fetch/extract/normalize core

### DIFF
--- a/generic_pipeline.py
+++ b/generic_pipeline.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+
+
+@dataclass
+class NormalizedItem:
+    dedupe_key: str
+    title: str
+    source_id: str
+    url: str = ""
+    description: str = ""
+    metric: str = ""
+    image_url: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PipelineResult:
+    source_id: str
+    items: list[NormalizedItem] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _str(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _json_field(record: dict[str, Any], key: str | None) -> str:
+    return _str(record.get(key)) if key else ""
+
+
+def _html_field(row: Tag, selector: str | None) -> str:
+    """Extract a field from an HTML row element.
+
+    Selector forms:
+      "css"        – text content of the first matched child (or row itself if no match)
+      "css@attr"   – attribute of the first matched child
+      "@attr"      – attribute of the row element itself
+      None / ""    – empty string
+    """
+    if not selector:
+        return ""
+    if "@" in selector:
+        css, attr = selector.rsplit("@", 1)
+        el: Tag | None = row.select_one(css.strip()) if css.strip() else row
+        return _str(el.get(attr) if el else None)
+    el = row.select_one(selector)
+    return el.get_text(strip=True) if el else ""
+
+
+def _build_item(
+    source_id: str,
+    dedupe_key: str,
+    title: str,
+    url: str,
+    description: str,
+    metric: str,
+    image_url: str,
+    raw: dict[str, Any],
+) -> NormalizedItem:
+    return NormalizedItem(
+        dedupe_key=dedupe_key.strip(),
+        title=title.strip(),
+        source_id=source_id,
+        url=url.strip(),
+        description=description.strip(),
+        metric=metric.strip(),
+        image_url=image_url.strip(),
+        raw=raw,
+    )
+
+
+def extract_from_json(
+    records: list[dict[str, Any]],
+    source_config: dict[str, Any],
+) -> PipelineResult:
+    source_id: str = source_config["id"]
+    fields: dict[str, Any] = source_config.get("fields", {})
+    limit: int = int(source_config.get("limit", len(records)))
+    result = PipelineResult(source_id=source_id)
+
+    for record in records[:limit]:
+        dedupe_key = _json_field(record, source_config.get("dedupe_key"))
+        title = _json_field(record, fields.get("title"))
+
+        if not dedupe_key or not title:
+            result.errors.append(
+                f"[{source_id}] record missing required field(s): "
+                f"dedupe_key={dedupe_key!r} title={title!r}"
+            )
+            continue
+
+        result.items.append(
+            _build_item(
+                source_id=source_id,
+                dedupe_key=dedupe_key,
+                title=title,
+                url=_json_field(record, fields.get("url")),
+                description=_json_field(record, fields.get("description")),
+                metric=_json_field(record, fields.get("metric")),
+                image_url=_json_field(record, fields.get("image_url")),
+                raw=record,
+            )
+        )
+
+    if not result.items and not result.errors:
+        result.errors.append(f"[{source_id}] extraction produced zero items")
+
+    return result
+
+
+def extract_from_html(
+    html: str,
+    source_config: dict[str, Any],
+) -> PipelineResult:
+    """Extract items from an HTML payload.
+
+    source_config must include:
+      row_selector  – CSS selector for the repeating item container
+      dedupe_key    – CSS selector (with optional @attr) for the dedup key
+      fields.title  – CSS selector (with optional @attr) for the title
+    """
+    source_id: str = source_config["id"]
+    fields: dict[str, Any] = source_config.get("fields", {})
+    limit: int = int(source_config.get("limit", 0))
+    row_selector: str = source_config.get("row_selector", "")
+    result = PipelineResult(source_id=source_id)
+
+    if not row_selector:
+        result.errors.append(f"[{source_id}] missing row_selector for html source")
+        return result
+
+    soup = BeautifulSoup(html, "html.parser")
+    rows: list[Tag] = list(soup.select(row_selector))
+    if limit:
+        rows = rows[:limit]
+
+    for row in rows:
+        dedupe_key = _html_field(row, source_config.get("dedupe_key"))
+        title = _html_field(row, fields.get("title"))
+
+        if not dedupe_key or not title:
+            result.errors.append(
+                f"[{source_id}] row missing required field(s): "
+                f"dedupe_key={dedupe_key!r} title={title!r}"
+            )
+            continue
+
+        result.items.append(
+            _build_item(
+                source_id=source_id,
+                dedupe_key=dedupe_key,
+                title=title,
+                url=_html_field(row, fields.get("url")),
+                description=_html_field(row, fields.get("description")),
+                metric=_html_field(row, fields.get("metric")),
+                image_url=_html_field(row, fields.get("image_url")),
+                raw={},
+            )
+        )
+
+    if not result.items and not result.errors:
+        result.errors.append(f"[{source_id}] extraction produced zero items")
+
+    return result

--- a/tests/test_generic_pipeline.py
+++ b/tests/test_generic_pipeline.py
@@ -1,0 +1,171 @@
+import unittest
+
+from generic_pipeline import PipelineResult, extract_from_html, extract_from_json
+
+_JSON_CONFIG = {
+    "id": "test_src",
+    "type": "json",
+    "limit": 10,
+    "dedupe_key": "id",
+    "fields": {
+        "title": "name",
+        "url": "link",
+        "description": "desc",
+        "metric": "score",
+        "image_url": None,
+    },
+}
+
+_HTML_CONFIG = {
+    "id": "test_html",
+    "type": "html",
+    "limit": 10,
+    "row_selector": "tr.item",
+    "dedupe_key": "td.key",
+    "fields": {
+        "title": "td.title",
+        "url": "a@href",
+        "description": "td.desc",
+        "metric": None,
+        "image_url": None,
+    },
+}
+
+_MINIMAL_HTML = """
+<table>
+  <tr class="item">
+    <td class="key">k1</td>
+    <td class="title">Film One</td>
+    <td class="desc">Action</td>
+    <td><a href="https://example.com/1">link</a></td>
+  </tr>
+  <tr class="item">
+    <td class="key">k2</td>
+    <td class="title">Film Two</td>
+    <td class="desc">Drama</td>
+    <td><a href="https://example.com/2">link</a></td>
+  </tr>
+</table>
+"""
+
+
+class TestExtractFromJson(unittest.TestCase):
+    def _records(self, n: int = 2) -> list[dict]:
+        return [
+            {
+                "id": str(i),
+                "name": f"Item {i}",
+                "link": f"https://x.com/{i}",
+                "desc": "d",
+                "score": str(i * 10),
+            }
+            for i in range(1, n + 1)
+        ]
+
+    def test_basic_extraction(self) -> None:
+        result = extract_from_json(self._records(), _JSON_CONFIG)
+        self.assertTrue(result.ok)
+        self.assertEqual(len(result.items), 2)
+        self.assertEqual(result.items[0].dedupe_key, "1")
+        self.assertEqual(result.items[0].title, "Item 1")
+        self.assertEqual(result.items[0].url, "https://x.com/1")
+        self.assertEqual(result.items[0].metric, "10")
+        self.assertEqual(result.items[0].source_id, "test_src")
+
+    def test_optional_fields_absent(self) -> None:
+        records = [{"id": "1", "name": "Only Required"}]
+        result = extract_from_json(records, _JSON_CONFIG)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.items[0].url, "")
+        self.assertEqual(result.items[0].description, "")
+        self.assertEqual(result.items[0].image_url, "")
+
+    def test_limit_applied(self) -> None:
+        config = {**_JSON_CONFIG, "limit": 1}
+        result = extract_from_json(self._records(5), config)
+        self.assertEqual(len(result.items), 1)
+
+    def test_dedupe_key_stripped(self) -> None:
+        records = [{"id": "  spaced  ", "name": "Title"}]
+        result = extract_from_json(records, _JSON_CONFIG)
+        self.assertEqual(result.items[0].dedupe_key, "spaced")
+
+    def test_missing_dedupe_key_goes_to_errors(self) -> None:
+        records = [{"name": "No Key"}]
+        result = extract_from_json(records, _JSON_CONFIG)
+        self.assertFalse(result.ok)
+        self.assertEqual(len(result.items), 0)
+        self.assertTrue(any("dedupe_key" in e for e in result.errors))
+
+    def test_missing_title_goes_to_errors(self) -> None:
+        records = [{"id": "1"}]
+        result = extract_from_json(records, _JSON_CONFIG)
+        self.assertFalse(result.ok)
+        self.assertTrue(any("title" in e for e in result.errors))
+
+    def test_zero_records_quality_failure(self) -> None:
+        result = extract_from_json([], _JSON_CONFIG)
+        self.assertFalse(result.ok)
+        self.assertTrue(any("zero items" in e for e in result.errors))
+
+    def test_mostly_invalid_records(self) -> None:
+        records = [{"name": "no key"} for _ in range(4)] + [{"id": "ok", "name": "Good"}]
+        result = extract_from_json(records, _JSON_CONFIG)
+        self.assertEqual(len(result.items), 1)
+        self.assertEqual(len(result.errors), 4)
+
+    def test_raw_preserved(self) -> None:
+        records = [{"id": "1", "name": "T", "extra": "data"}]
+        result = extract_from_json(records, _JSON_CONFIG)
+        self.assertEqual(result.items[0].raw["extra"], "data")
+
+
+class TestExtractFromHtml(unittest.TestCase):
+    def test_basic_extraction(self) -> None:
+        result = extract_from_html(_MINIMAL_HTML, _HTML_CONFIG)
+        self.assertTrue(result.ok)
+        self.assertEqual(len(result.items), 2)
+        self.assertEqual(result.items[0].dedupe_key, "k1")
+        self.assertEqual(result.items[0].title, "Film One")
+        self.assertEqual(result.items[0].description, "Action")
+        self.assertEqual(result.items[0].url, "https://example.com/1")
+
+    def test_limit_applied(self) -> None:
+        config = {**_HTML_CONFIG, "limit": 1}
+        result = extract_from_html(_MINIMAL_HTML, config)
+        self.assertEqual(len(result.items), 1)
+
+    def test_optional_field_absent(self) -> None:
+        result = extract_from_html(_MINIMAL_HTML, _HTML_CONFIG)
+        self.assertEqual(result.items[0].metric, "")
+        self.assertEqual(result.items[0].image_url, "")
+
+    def test_missing_row_selector_is_error(self) -> None:
+        config = {**_HTML_CONFIG, "row_selector": ""}
+        result = extract_from_html(_MINIMAL_HTML, config)
+        self.assertFalse(result.ok)
+        self.assertTrue(any("row_selector" in e for e in result.errors))
+
+    def test_empty_html_quality_failure(self) -> None:
+        result = extract_from_html("<html></html>", _HTML_CONFIG)
+        self.assertFalse(result.ok)
+        self.assertTrue(any("zero items" in e for e in result.errors))
+
+    def test_attr_extraction(self) -> None:
+        html = '<table><tr class="item"><td class="key">k</td><td class="title">T</td><td><a href="https://x.com">x</a></td></tr></table>'
+        result = extract_from_html(html, _HTML_CONFIG)
+        self.assertEqual(result.items[0].url, "https://x.com")
+
+
+class TestPipelineResult(unittest.TestCase):
+    def test_ok_true_when_no_errors(self) -> None:
+        r = PipelineResult(source_id="s")
+        self.assertTrue(r.ok)
+
+    def test_ok_false_when_errors(self) -> None:
+        r = PipelineResult(source_id="s", errors=["bad"])
+        self.assertFalse(r.ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2

## Changes

**`generic_pipeline.py`**
- `NormalizedItem` — dataclass с полями: `dedupe_key`, `title`, `source_id`, `url`, `description`, `metric`, `image_url`, `raw`
- `PipelineResult` — dataclass с `items`, `errors`, `warnings`, свойство `ok`
- `extract_from_json(records, source_config)` — flat key mapping, limit, quality checks
- `extract_from_html(html, source_config)` — `row_selector` + `css@attr` синтаксис для атрибутов, limit

Нет сетевых вызовов — полностью тестируется с in-memory payload. Использует только `bs4` из уже существующих зависимостей.

**`tests/test_generic_pipeline.py`** — 17 unit-тестов: JSON и HTML экстракция, required field validation, optional field absence, limit, trimming dedupe key, zero-item quality failure, raw preservation.

## Runtime safety

`scraper.py`, `TelegramChannelSummarizer.py`, `crypto.py`, `run-script.yml` не изменены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)