### PR TITLE
[#3] Add Google Sheets storage layer

### DIFF
--- a/generic_pipeline.py
+++ b/generic_pipeline.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from bs4 import BeautifulSoup, Tag
+
+ROW_HEADERS = ["dedupe_key", "title", "url", "metric", "source_id", "notified_at"]
 
 
 @dataclass
@@ -16,6 +19,10 @@ class NormalizedItem:
     metric: str = ""
     image_url: str = ""
     raw: dict[str, Any] = field(default_factory=dict)
+
+    def to_row(self, notified_at: datetime | None = None) -> list[Any]:
+        ts = (notified_at or datetime.now(UTC)).isoformat()
+        return [self.dedupe_key, self.title, self.url, self.metric, self.source_id, ts]
 
 
 @dataclass

--- a/sheets_storage.py
+++ b/sheets_storage.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Protocol, runtime_checkable
+
+import gspread
+import gspread.exceptions
+
+from generic_pipeline import ROW_HEADERS
+
+
+@runtime_checkable
+class Storage(Protocol):
+    def get_existing_keys(self, tab_name: str) -> set[str]: ...
+
+    def append_rows(self, tab_name: str, rows: list[list[Any]]) -> None: ...
+
+
+class SheetsStorage:
+    """Google Sheets backed storage. Accepts an already-authenticated gspread.Client."""
+
+    def __init__(self, client: gspread.Client, spreadsheet_url: str) -> None:
+        self._spreadsheet = client.open_by_url(spreadsheet_url)
+
+    def _get_or_create_worksheet(self, tab_name: str) -> gspread.Worksheet:
+        try:
+            return self._spreadsheet.worksheet(tab_name)
+        except gspread.exceptions.WorksheetNotFound:
+            ws = self._spreadsheet.add_worksheet(title=tab_name, rows=1000, cols=len(ROW_HEADERS))
+            ws.append_row(ROW_HEADERS)
+            return ws
+
+    def get_existing_keys(self, tab_name: str) -> set[str]:
+        ws = self._get_or_create_worksheet(tab_name)
+        # read header row to find dedupe_key column index dynamically
+        headers = ws.row_values(1)
+        try:
+            key_col = headers.index("dedupe_key") + 1  # 1-based
+        except ValueError:
+            return set()
+        col_values = ws.col_values(key_col)
+        # skip header
+        return {str(v).strip() for v in col_values[1:] if v and str(v).strip()}
+
+    def append_rows(self, tab_name: str, rows: list[list[Any]]) -> None:
+        if not rows:
+            return
+        ws = self._get_or_create_worksheet(tab_name)
+        ws.append_rows(rows, value_input_option=gspread.utils.ValueInputOption.user_entered)
+
+
+class InMemoryStorage:
+    """In-memory Storage for use in tests and dry runs."""
+
+    def __init__(self) -> None:
+        self._keys: dict[str, set[str]] = defaultdict(set)
+        self._rows: dict[str, list[list[Any]]] = defaultdict(list)
+
+    def get_existing_keys(self, tab_name: str) -> set[str]:
+        return set(self._keys[tab_name])
+
+    def append_rows(self, tab_name: str, rows: list[list[Any]]) -> None:
+        for row in rows:
+            self._rows[tab_name].append(row)
+            if row:
+                self._keys[tab_name].add(str(row[0]))
+
+    def stored_rows(self, tab_name: str) -> list[list[Any]]:
+        return list(self._rows[tab_name])

--- a/tests/test_sheets_storage.py
+++ b/tests/test_sheets_storage.py
@@ -1,0 +1,88 @@
+import unittest
+from datetime import UTC, datetime
+
+from generic_pipeline import ROW_HEADERS, NormalizedItem
+from sheets_storage import InMemoryStorage, Storage
+
+
+def _item(dedupe_key: str = "k1", source_id: str = "src") -> NormalizedItem:
+    return NormalizedItem(
+        dedupe_key=dedupe_key,
+        title="Title",
+        source_id=source_id,
+        url="https://example.com",
+        metric="42",
+    )
+
+
+class TestToRow(unittest.TestCase):
+    def test_row_length_matches_headers(self) -> None:
+        row = _item().to_row()
+        self.assertEqual(len(row), len(ROW_HEADERS))
+
+    def test_row_fields_order(self) -> None:
+        item = _item(dedupe_key="dk")
+        row = item.to_row()
+        self.assertEqual(row[ROW_HEADERS.index("dedupe_key")], "dk")
+        self.assertEqual(row[ROW_HEADERS.index("title")], "Title")
+        self.assertEqual(row[ROW_HEADERS.index("url")], "https://example.com")
+        self.assertEqual(row[ROW_HEADERS.index("metric")], "42")
+        self.assertEqual(row[ROW_HEADERS.index("source_id")], "src")
+
+    def test_notified_at_injected(self) -> None:
+        ts = datetime(2024, 3, 15, 12, 0, 0, tzinfo=UTC)
+        row = _item().to_row(notified_at=ts)
+        self.assertIn("2024-03-15", row[ROW_HEADERS.index("notified_at")])
+
+    def test_notified_at_defaults_to_now(self) -> None:
+        row = _item().to_row()
+        notified_at = row[ROW_HEADERS.index("notified_at")]
+        self.assertIsInstance(notified_at, str)
+        self.assertTrue(notified_at)
+
+
+class TestInMemoryStorage(unittest.TestCase):
+    def setUp(self) -> None:
+        self.storage = InMemoryStorage()
+
+    def test_implements_storage_protocol(self) -> None:
+        self.assertIsInstance(self.storage, Storage)
+
+    def test_empty_tab_returns_empty_set(self) -> None:
+        self.assertEqual(self.storage.get_existing_keys("movies"), set())
+
+    def test_append_then_get_keys(self) -> None:
+        rows = [_item("k1").to_row(), _item("k2").to_row()]
+        self.storage.append_rows("movies", rows)
+        keys = self.storage.get_existing_keys("movies")
+        self.assertIn("k1", keys)
+        self.assertIn("k2", keys)
+
+    def test_existing_key_lookup(self) -> None:
+        self.storage.append_rows("movies", [_item("existing").to_row()])
+        self.assertIn("existing", self.storage.get_existing_keys("movies"))
+        self.assertNotIn("new", self.storage.get_existing_keys("movies"))
+
+    def test_tabs_are_isolated(self) -> None:
+        self.storage.append_rows("tab_a", [_item("k1").to_row()])
+        self.storage.append_rows("tab_b", [_item("k2").to_row()])
+        self.assertNotIn("k2", self.storage.get_existing_keys("tab_a"))
+        self.assertNotIn("k1", self.storage.get_existing_keys("tab_b"))
+
+    def test_append_empty_rows_noop(self) -> None:
+        self.storage.append_rows("movies", [])
+        self.assertEqual(self.storage.stored_rows("movies"), [])
+
+    def test_stored_rows_accessible(self) -> None:
+        row = _item("k1").to_row()
+        self.storage.append_rows("movies", [row])
+        self.assertEqual(self.storage.stored_rows("movies"), [row])
+
+    def test_multiple_appends_accumulate(self) -> None:
+        self.storage.append_rows("movies", [_item("k1").to_row()])
+        self.storage.append_rows("movies", [_item("k2").to_row()])
+        self.assertEqual(len(self.storage.stored_rows("movies")), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #3

## Changes

**`generic_pipeline.py`** — добавлен `ROW_HEADERS` и `NormalizedItem.to_row(notified_at?)`.
Порядок полей: `dedupe_key | title | url | metric | source_id | notified_at`.

**`sheets_storage.py`**
- `Storage(Protocol)` — чистый интерфейс, `runtime_checkable`
- `SheetsStorage(client, spreadsheet_url)` — принимает готовый `gspread.Client` (DI):
  - EAFP: `try worksheet() / except WorksheetNotFound → create + headers` — меньше API-запросов
  - Колонка `dedupe_key` ищется динамически по заголовку, не по индексу
- `InMemoryStorage` — чистый Python, реализует тот же Protocol; используется в тестах и dry-run

**`tests/test_sheets_storage.py`** — 12 unit-тестов: `to_row()`, контракт `InMemoryStorage`, изоляция табов, накопление строк. Ни одного мока gspread.

## Runtime safety

`scraper.py`, `run-script.yml` не изменены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)