### PR TITLE
docs: add architecture decision records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,14 @@ python scripts/ci_check.py
 ```
 Pre-push hook активирован через `git config core.hooksPath .githooks` — запускается автоматически при пуше.
 
+## Architecture decisions
+
+Key decisions recorded here; details in separate files to keep this file short.
+
+- [Testing](docs/architecture/testing.md) — no mocks on external APIs, use Protocol + InMemoryStorage
+- [Pipeline](docs/architecture/pipeline.md) — layers, NormalizedItem, extract_from_* contracts
+- [Storage](docs/architecture/storage.md) — Storage Protocol, DI, EAFP, row schema
+
 ## Установка окружения
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -1,0 +1,68 @@
+# Pipeline architecture
+
+## Layers
+
+```
+sources.json          declarative config (urls, selectors, limits, macros)
+pipeline_config.py    loads config, expands macros, validates schema
+generic_pipeline.py   extract + normalize (no network, no I/O)
+sheets_storage.py     read existing keys, append confirmed rows
+telegram_notifier.py  send items, return confirmed list  [issue #4]
+scraper.py            legacy runtime — untouched until issue #5
+```
+
+## Key principle: new source = config, not code
+
+Adding GitHub, Steam, or any future source requires only a new entry in
+`sources.json`. No new Python class, no new extractor.
+
+## Data flow (issues #2–#5)
+
+```
+load_sources_config()
+  → for each enabled source:
+      fetch payload (HTTP, done by caller)
+      extract_from_json / extract_from_html  → PipelineResult
+      storage.get_existing_keys(sheet_tab)   → set[str]
+      filter new items (dedupe_key not in existing keys)
+      notifier.send(new_items)               → confirmed_items
+      storage.append_rows(sheet_tab, [item.to_row() for item in confirmed_items])
+```
+
+## NormalizedItem
+
+Defined in `generic_pipeline.py`. All pipeline stages pass this type.
+
+```python
+@dataclass
+class NormalizedItem:
+    dedupe_key: str      # unique key for deduplication (required)
+    title: str           # display title (required)
+    source_id: str       # matches sources.json id
+    url: str
+    description: str
+    metric: str
+    image_url: str
+    raw: dict            # original record for debugging
+```
+
+Row serialization: `item.to_row()` → `[dedupe_key, title, url, metric, source_id, notified_at]`
+Headers constant: `ROW_HEADERS` in `generic_pipeline.py`
+
+## extract_from_* contracts
+
+- Take in-memory payload (list of dicts for JSON, HTML string for HTML)
+- Return `PipelineResult(items, errors, warnings)`
+- Zero items extracted → `errors` entry (quality failure)
+- Missing `dedupe_key` or `title` on a record → `errors` entry, item skipped
+- Never raise for data quality issues — caller decides what to do
+
+## HTML source config
+
+HTML sources require `row_selector` in source config (not in `fields`).
+Field selectors use `css@attr` syntax to extract attributes.
+
+## Macro expansion
+
+Handled by `pipeline_config.py` before the pipeline runs.
+Supported macros: `{{TODAY}}`, `{{DATE_MINUS_7_DAYS}}`, `{{GITHUB_TOP_LIMIT}}`, `{{STEAM_TOP_LIMIT}}`.

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,0 +1,58 @@
+# Storage architecture
+
+## Pattern: Protocol + implementations
+
+```python
+# sheets_storage.py
+class Storage(Protocol):
+    def get_existing_keys(self, tab_name: str) -> set[str]: ...
+    def append_rows(self, tab_name: str, rows: list[list[Any]]) -> None: ...
+
+class SheetsStorage:      # production
+class InMemoryStorage:    # tests and dry-runs
+```
+
+Callers type-hint against `Storage`, not `SheetsStorage`. This makes any
+code that uses storage trivially testable without touching gspread.
+
+## Dependency injection
+
+`SheetsStorage` accepts a ready `gspread.Client`, not credentials dict.
+Construction of the client (auth, spreadsheet URL) is the caller's
+responsibility. Reason: separates configuration from execution, makes
+the class easier to compose and test.
+
+```python
+# correct
+client = gspread.service_account_from_dict(credentials)
+storage = SheetsStorage(client, spreadsheet_url)
+
+# wrong — mixes auth into the storage layer
+storage = SheetsStorage(credentials_dict, spreadsheet_url)
+```
+
+## EAFP worksheet creation
+
+Use try/except, not check-then-create. Reduces API calls 2–3× for the
+common case (tab already exists), avoids Google Sheets quota errors.
+
+```python
+try:
+    ws = spreadsheet.worksheet(tab_name)
+except WorksheetNotFound:
+    ws = spreadsheet.add_worksheet(...)
+    ws.append_row(ROW_HEADERS)
+```
+
+## Dedupe key column lookup
+
+Column index is found dynamically by reading the header row and searching
+for `"dedupe_key"`. Never hardcode column A or index 0.
+
+## Row schema
+
+`ROW_HEADERS` in `generic_pipeline.py`:
+`["dedupe_key", "title", "url", "metric", "source_id", "notified_at"]`
+
+Only append rows for items confirmed sent by Telegram. Never persist
+items that failed to send.

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -1,0 +1,35 @@
+# Testing philosophy
+
+## Rule: no mocks on external APIs
+
+Do not mock `gspread`, `telethon`, `google.generativeai`, or any other external
+library. Fake objects for deep API hierarchies are fragile — they pass tests
+while real integration silently breaks (different return types, quota errors,
+missing fields).
+
+**Instead:**
+- Extract pure functions (row construction, field mapping, normalization) and
+  unit-test those directly — no mocks needed.
+- Define a `Protocol` for each external boundary and provide an in-memory
+  implementation for tests (`InMemoryStorage`, future `InMemoryNotifier`).
+- Integration tests against real external services belong in a separate test
+  suite, run manually against a dedicated test document/channel.
+
+## What gets unit-tested
+
+- All pure transformation logic: macro expansion, field mapping, normalization,
+  row construction, deduplication key lookups.
+- Protocol contract: `InMemoryStorage` tests verify the `Storage` interface.
+
+## What does NOT get unit-tested in this repo
+
+- `SheetsStorage` internals (gspread call order, worksheet creation).
+- `TelegramChannelSummarizer` / Telethon calls.
+- Any code path that requires live credentials.
+
+## Test runner
+
+```bash
+python -m pytest          # via pyproject.toml config
+python scripts/ci_check.py  # full CI mirror: format + lint + tests + mypy
+```


### PR DESCRIPTION
## Summary

- `CLAUDE.md` updated to link to detail files instead of growing inline
- `docs/architecture/testing.md` — no mocks on external APIs, Protocol + InMemoryStorage pattern
- `docs/architecture/pipeline.md` — layers, NormalizedItem, extract_from_* contracts, data flow
- `docs/architecture/storage.md` — Storage Protocol, DI rationale, EAFP, row schema

Enables starting each issue in a **fresh chat** without losing architectural context established in issues #1–#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)