### PR TITLE
fix: align grpcio-status to 1.80.0 to match grpcio pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ grpcio==1.80.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.80.0
+grpcio-status==1.67.1
     # via google-api-core
 gspread==6.2.1
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ grpcio==1.80.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.71.2
+grpcio-status==1.80.0
     # via google-api-core
 gspread==6.2.1
     # via -r requirements.in


### PR DESCRIPTION
## Problem

`requirements.txt` had conflicting pins:
- `grpcio==1.80.0`
- `grpcio-status==1.71.2` — requires `grpcio<1.72`

pip's dependency resolver started catching this conflict, breaking both manual `workflow_dispatch` runs and scheduled runs (the scheduled run at 05:04 UTC today succeeded only due to runner cache — next run would fail clean).

## Fix

Bump `grpcio-status` from `1.71.2` → `1.80.0` to match the already-pinned `grpcio==1.80.0`.

## Test plan

- [ ] Trigger `workflow_dispatch` on main after merge — install step should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)