### PR TITLE
feat(#6): generic JSON pipeline runner + GitHub source

### DIFF
--- a/generic_pipeline.py
+++ b/generic_pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html as _html
+import re
 import urllib.parse
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -195,6 +196,7 @@ def extract_from_html(
 
 _URL_FIELDS: frozenset[str] = frozenset({"url", "image_url", "trailer_url"})
 _NUMBER_FIELDS: frozenset[str] = frozenset({"metric"})
+_PLACEHOLDER_RE = re.compile(r"\{(\w+)\}")
 
 
 @dataclass
@@ -229,4 +231,9 @@ def build_notification(item: NormalizedItem, template: str) -> Notification:
     text = template
     for field_name, raw_value in values.items():
         text = text.replace(f"{{{field_name}}}", _format_field(field_name, raw_value))
+    for match in _PLACEHOLDER_RE.finditer(text):
+        field_name = match.group(1)
+        if field_name not in values:
+            raw_value = item.raw.get(field_name)
+            text = text.replace(f"{{{field_name}}}", _format_field(field_name, raw_value))
     return Notification(id=item.dedupe_key, text=text.strip(), image_url=item.image_url)

--- a/json_pipeline.py
+++ b/json_pipeline.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import requests
+
+from generic_pipeline import (
+    ROW_HEADERS,
+    build_notification,
+    extract_from_json,
+)
+from pipeline_config import load_sources_config
+from sheets_storage import Storage
+from telegram_notifier import Notifier
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch_json(url: str, params: dict[str, str], headers: dict[str, str]) -> Any:
+    clean_headers = {k: v for k, v in headers.items() if v and not v.endswith(" ")}
+    resp = requests.get(url, params=params, headers=clean_headers, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _unwrap_records(data: Any, json_path: str | None) -> list[dict[str, Any]]:
+    """Navigate into the response to find the records array."""
+    if json_path is None:
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return list(data.values()) if all(isinstance(v, dict) for v in data.values()) else []
+        return []
+    obj: Any = data
+    for key in json_path.split("."):
+        obj = obj.get(key, []) if isinstance(obj, dict) else []
+    return obj if isinstance(obj, list) else []
+
+
+def run_json_pipeline(
+    storage: Storage,
+    notifier: Notifier,
+    sources_config: dict[str, Any] | None = None,
+) -> None:
+    config = sources_config or load_sources_config()
+    json_sources = [s for s in config["sources"] if s.get("enabled") and s["type"] == "json"]
+    if not json_sources:
+        logger.info("no enabled json sources found")
+        return
+
+    for source in json_sources:
+        try:
+            _run_single_source(source, storage, notifier)
+        except Exception as exc:
+            logger.error("[%s] unhandled error: %s", source["id"], exc)
+            continue
+
+
+def _run_single_source(source: dict[str, Any], storage: Storage, notifier: Notifier) -> None:
+    source_id = source["id"]
+
+    data = _fetch_json(
+        source["url"],
+        source.get("params", {}),
+        source.get("headers", {}),
+    )
+
+    records = _unwrap_records(data, source.get("json_path"))
+    result = extract_from_json(records, source)
+    if not result.ok:
+        logger.error("[%s] extraction errors: %s", source_id, result.errors)
+        return
+
+    tab = source["sheet_tab"]
+    existing = storage.get_existing_keys(tab)
+    new_items = [i for i in result.items if i.dedupe_key not in existing]
+    if not new_items:
+        logger.info("[%s] no new items", source_id)
+        return
+
+    template = source["message_template"]
+    notifications = [build_notification(item, template) for item in new_items]
+    sent, failed = notifier.send_items(notifications)
+
+    if sent:
+        sent_ids = {n.id for n in sent}
+        items_to_store = [i for i in new_items if i.dedupe_key in sent_ids]
+        storage.append_rows(tab, ROW_HEADERS, [i.to_row() for i in items_to_store])
+
+    if failed:
+        logger.warning(
+            "[%s] %d notification(s) failed, will retry next run", source_id, len(failed)
+        )
+
+
+if __name__ == "__main__":
+    import os
+
+    import gspread
+
+    from sheets_storage import SheetsStorage
+    from telegram_notifier import TelegramNotifier
+
+    gc = gspread.service_account()
+    prod_storage = SheetsStorage(gc, os.environ["SPREADSHEET_URL"])
+    prod_notifier = TelegramNotifier(
+        bot_token=os.environ["TELEGRAM_BOT_TOKEN"],
+        chat_id=os.environ["TELEGRAM_CHAT_ID"],
+    )
+    run_json_pipeline(prod_storage, prod_notifier)

--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -40,6 +40,7 @@ def build_macro_context(
         "TODAY": today.isoformat(),
         "DATE_MINUS_7_DAYS": (today - timedelta(days=7)).isoformat(),
         "GITHUB_TOP_LIMIT": env.get("GITHUB_TOP_LIMIT", "10"),
+        "GITHUB_TOKEN": env.get("GITHUB_TOKEN", ""),
         "STEAM_TOP_LIMIT": env.get("STEAM_TOP_LIMIT", "10"),
         "KINOZAL_TOP_URL": env.get("KINOZAL_TOP_URL", ""),
     }

--- a/sources.json
+++ b/sources.json
@@ -3,9 +3,14 @@
   "sources": [
     {
       "id": "github_new_popular",
-      "enabled": false,
+      "enabled": true,
       "type": "json",
       "url": "https://api.github.com/search/repositories",
+      "json_path": "items",
+      "headers": {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "Bearer {{GITHUB_TOKEN}}"
+      },
       "params": {
         "q": "created:>={{DATE_MINUS_7_DAYS}}",
         "sort": "stars",
@@ -22,7 +27,7 @@
         "metric": "stargazers_count",
         "image_url": null
       },
-      "message_template": "<b>{title}</b>\n{description}\nStars: {metric}\n{url}"
+      "message_template": "<b>{title}</b>\n{description}\n⭐ {metric} | {language}\n{url}"
     },
     {
       "id": "steam_top_games",

--- a/tests/test_generic_pipeline.py
+++ b/tests/test_generic_pipeline.py
@@ -1,6 +1,12 @@
 import unittest
 
-from generic_pipeline import PipelineResult, extract_from_html, extract_from_json
+from generic_pipeline import (
+    NormalizedItem,
+    PipelineResult,
+    build_notification,
+    extract_from_html,
+    extract_from_json,
+)
 
 _JSON_CONFIG = {
     "id": "test_src",
@@ -165,6 +171,32 @@ class TestPipelineResult(unittest.TestCase):
     def test_ok_false_when_errors(self) -> None:
         r = PipelineResult(source_id="s", errors=["bad"])
         self.assertFalse(r.ok)
+
+
+class TestBuildNotificationRawFallback(unittest.TestCase):
+    def test_raw_field_resolved_in_template(self) -> None:
+        item = NormalizedItem(
+            dedupe_key="user/repo",
+            title="user/repo",
+            source_id="test",
+            url="https://github.com/user/repo",
+            metric="42",
+            raw={"language": "Python", "forks": 10},
+        )
+        note = build_notification(item, "<b>{title}</b> | {language} | {forks}")
+        self.assertIn("Python", note.text)
+        self.assertIn("10", note.text)
+
+    def test_missing_raw_key_resolves_to_empty(self) -> None:
+        item = NormalizedItem(dedupe_key="x", title="x", source_id="t", raw={})
+        note = build_notification(item, "{title} | {nonexistent}")
+        self.assertIn("x |", note.text)
+        self.assertNotIn("nonexistent", note.text)
+
+    def test_none_raw_value_resolves_to_empty(self) -> None:
+        item = NormalizedItem(dedupe_key="x", title="x", source_id="t", raw={"language": None})
+        note = build_notification(item, "{title} | {language}")
+        self.assertNotIn("None", note.text)
 
 
 if __name__ == "__main__":

--- a/tests/test_json_pipeline.py
+++ b/tests/test_json_pipeline.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import unittest
+import unittest.mock
+from typing import Any
+
+from json_pipeline import _unwrap_records, run_json_pipeline
+from sheets_storage import InMemoryStorage
+from telegram_notifier import InMemoryNotifier
+
+_GITHUB_RESPONSE: dict[str, Any] = {
+    "total_count": 3,
+    "items": [
+        {
+            "full_name": "user/repo-alpha",
+            "html_url": "https://github.com/user/repo-alpha",
+            "description": "A cool project",
+            "stargazers_count": 500,
+            "language": "Python",
+        },
+        {
+            "full_name": "org/repo-beta",
+            "html_url": "https://github.com/org/repo-beta",
+            "description": None,
+            "stargazers_count": 300,
+            "language": None,
+        },
+        {
+            "full_name": "dev/repo-gamma",
+            "html_url": "https://github.com/dev/repo-gamma",
+            "description": "Third project",
+            "stargazers_count": 100,
+            "language": "Rust",
+        },
+    ],
+}
+
+_GITHUB_SOURCE: dict[str, Any] = {
+    "id": "github_new_popular",
+    "enabled": True,
+    "type": "json",
+    "url": "https://api.github.com/search/repositories",
+    "json_path": "items",
+    "headers": {
+        "Accept": "application/vnd.github.v3+json",
+        "Authorization": "Bearer test-token",
+    },
+    "params": {"q": "created:>=2026-04-26", "sort": "stars", "order": "desc", "per_page": "10"},
+    "limit": 10,
+    "sheet_tab": "github_projects",
+    "dedupe_key": "full_name",
+    "fields": {
+        "title": "full_name",
+        "url": "html_url",
+        "description": "description",
+        "metric": "stargazers_count",
+        "image_url": None,
+    },
+    "message_template": "<b>{title}</b>\n{description}\n⭐ {metric} | {language}\n{url}",
+}
+
+_CONFIG: dict[str, Any] = {"version": 1, "sources": [_GITHUB_SOURCE]}
+
+
+def _patch_fetch(response: Any) -> unittest.mock._patch[unittest.mock.MagicMock]:
+    return unittest.mock.patch("json_pipeline._fetch_json", return_value=response)
+
+
+class TestUnwrapRecords(unittest.TestCase):
+    def test_json_path_items(self) -> None:
+        data = {"total_count": 2, "items": [{"a": 1}, {"b": 2}]}
+        self.assertEqual(_unwrap_records(data, "items"), [{"a": 1}, {"b": 2}])
+
+    def test_nested_json_path(self) -> None:
+        data = {"response": {"data": [{"x": 1}]}}
+        self.assertEqual(_unwrap_records(data, "response.data"), [{"x": 1}])
+
+    def test_none_path_with_list(self) -> None:
+        data = [{"a": 1}]
+        self.assertEqual(_unwrap_records(data, None), [{"a": 1}])
+
+    def test_none_path_with_dict_of_dicts(self) -> None:
+        data = {"100": {"name": "Game A"}, "200": {"name": "Game B"}}
+        result = _unwrap_records(data, None)
+        self.assertEqual(len(result), 2)
+        self.assertIn({"name": "Game A"}, result)
+
+    def test_none_path_with_non_dict_values(self) -> None:
+        data = {"key": "string_value"}
+        self.assertEqual(_unwrap_records(data, None), [])
+
+    def test_missing_key_returns_empty(self) -> None:
+        data = {"other": [1, 2, 3]}
+        self.assertEqual(_unwrap_records(data, "items"), [])
+
+    def test_non_list_at_path_returns_empty(self) -> None:
+        data = {"items": "not a list"}
+        self.assertEqual(_unwrap_records(data, "items"), [])
+
+
+class TestJsonPipelineHappyPath(unittest.TestCase):
+    def test_items_extracted_notified_stored(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_GITHUB_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 3)
+        self.assertEqual(len(storage.stored_rows("github_projects")), 3)
+        self.assertEqual(storage.stored_rows("github_projects")[0][0], "user/repo-alpha")
+
+    def test_notification_contains_language(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_GITHUB_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        text = notifier.sent[0].text
+        self.assertIn("Python", text)
+        self.assertIn("⭐ 500", text)
+
+
+class TestJsonPipelineDeduplication(unittest.TestCase):
+    def test_existing_keys_not_re_notified(self) -> None:
+        storage = InMemoryStorage()
+        storage._keys["github_projects"].add("user/repo-alpha")
+        storage._keys["github_projects"].add("org/repo-beta")
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_GITHUB_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 1)
+        self.assertEqual(notifier.sent[0].id, "dev/repo-gamma")
+
+
+class TestJsonPipelineNullFields(unittest.TestCase):
+    def test_null_description_and_language(self) -> None:
+        response = {
+            "items": [
+                {
+                    "full_name": "x/null-fields",
+                    "html_url": "https://github.com/x/null-fields",
+                    "description": None,
+                    "stargazers_count": 10,
+                    "language": None,
+                }
+            ]
+        }
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(response):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 1)
+        self.assertNotIn("None", notifier.sent[0].text)
+
+
+class TestJsonPipelineEmptyResponse(unittest.TestCase):
+    def test_empty_items_no_crash(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch({"items": []}):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 0)
+        self.assertEqual(len(storage.stored_rows("github_projects")), 0)
+
+
+class TestJsonPipelineFailedNotifications(unittest.TestCase):
+    def test_failed_items_not_stored(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier(fail_ids={"user/repo-alpha", "org/repo-beta"})
+
+        with _patch_fetch(_GITHUB_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        self.assertEqual(len(storage.stored_rows("github_projects")), 1)
+        self.assertEqual(storage.stored_rows("github_projects")[0][0], "dev/repo-gamma")
+
+
+class TestJsonPipelineSourceIsolation(unittest.TestCase):
+    def test_one_source_error_does_not_block_others(self) -> None:
+        broken_source: dict[str, Any] = {
+            **_GITHUB_SOURCE,
+            "id": "broken_source",
+            "url": "https://broken.example.com",
+            "sheet_tab": "broken",
+        }
+        config = {"version": 1, "sources": [broken_source, _GITHUB_SOURCE]}
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        def side_effect(url: str, params: Any, headers: Any) -> Any:
+            if "broken" in url:
+                raise ConnectionError("network down")
+            return _GITHUB_RESPONSE
+
+        with unittest.mock.patch("json_pipeline._fetch_json", side_effect=side_effect):
+            run_json_pipeline(storage, notifier, sources_config=config)
+
+        self.assertEqual(len(notifier.sent), 3)
+
+
+class TestEmptyAuthHeaderStripped(unittest.TestCase):
+    def test_bearer_space_not_sent(self) -> None:
+        source = {**_GITHUB_SOURCE, "headers": {"Authorization": "Bearer "}}
+        config = {"version": 1, "sources": [source]}
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with unittest.mock.patch("json_pipeline.requests.get") as mock_get:
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = _GITHUB_RESPONSE
+            mock_get.return_value.raise_for_status = lambda: None
+            run_json_pipeline(storage, notifier, sources_config=config)
+
+            _, kwargs = mock_get.call_args
+            self.assertNotIn("Authorization", kwargs.get("headers", {}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `json_pipeline.py` — a generic runner for any JSON source declared in `sources.json`, eliminating per-source pipeline code
- Enables `github_new_popular` source (GitHub Search API, repos created in last 7 days, sorted by stars)
- Extends `build_notification` to resolve `{placeholder}` from `item.raw`, making any API field usable in templates declaratively

## Key architectural decisions

| Decision | Rationale |
|----------|-----------|
| **At-least-once delivery** (notify → store only sent) | Failed notifications retry next run instead of being lost forever |
| **Declarative `headers`** with `{{GITHUB_TOKEN}}` macro | Graceful degradation without token; no code change for auth |
| **`json_path`** field | GitHub `"items"`, Steam dict-of-dicts — one runner handles both |
| **Source isolation** (try/except per source) | One API failure does not block others |
| **Empty auth header stripping** | `"Bearer "` (no token) → header omitted entirely |

## Files changed

| File | What |
|------|------|
| `json_pipeline.py` | New generic JSON source runner (~100 lines) |
| `tests/test_json_pipeline.py` | 15 tests: happy path, dedup, null fields, failed notifications, isolation |
| `sources.json` | Added `json_path`, `headers`, updated template, enabled GitHub source |
| `generic_pipeline.py` | `build_notification` raw-field fallback (+8 lines) |
| `pipeline_config.py` | Added `GITHUB_TOKEN` to macro context (+1 line) |
| `tests/test_generic_pipeline.py` | 3 tests for raw-fallback behavior |

## Test plan

- [x] All 120 tests pass (`python scripts/ci_check.py`)
- [x] ruff format + lint clean
- [x] mypy strict — no errors
- [ ] Live test with `GITHUB_TOKEN` set (manual, requires token)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)