### PR TITLE
feat(#7): add Steam top games source via SteamSpy

### DIFF
--- a/json_pipeline.py
+++ b/json_pipeline.py
@@ -67,6 +67,13 @@ def _run_single_source(source: dict[str, Any], storage: Storage, notifier: Notif
     )
 
     records = _unwrap_records(data, source.get("json_path"))
+
+    sort_key = source.get("sort_by")
+    if sort_key:
+        records.sort(
+            key=lambda r: int(r.get(sort_key) or 0), reverse=source.get("sort_reverse", False)
+        )
+
     result = extract_from_json(records, source)
     if not result.ok:
         logger.error("[%s] extraction errors: %s", source_id, result.errors)

--- a/sources.json
+++ b/sources.json
@@ -31,12 +31,14 @@
     },
     {
       "id": "steam_top_games",
-      "enabled": false,
+      "enabled": true,
       "type": "json",
       "url": "https://steamspy.com/api.php",
       "params": {
         "request": "top100in2weeks"
       },
+      "sort_by": "ccu",
+      "sort_reverse": true,
       "limit": "{{STEAM_TOP_LIMIT}}",
       "sheet_tab": "steam_games",
       "dedupe_key": "appid",
@@ -47,7 +49,7 @@
         "metric": "ccu",
         "image_url": null
       },
-      "message_template": "<b>{title}</b>\nDeveloper: {description}\nPlayers: {metric}\n{url}"
+      "message_template": "<b>{title}</b>\nDeveloper: {description}\nPlayers: {metric}\nhttps://store.steampowered.com/app/{appid}"
     },
     {
       "id": "kinozal_movies",

--- a/tests/test_json_pipeline.py
+++ b/tests/test_json_pipeline.py
@@ -223,5 +223,128 @@ class TestEmptyAuthHeaderStripped(unittest.TestCase):
             self.assertNotIn("Authorization", kwargs.get("headers", {}))
 
 
+# ── Steam source tests ──────────────────────────────────────────────────────
+
+_STEAM_RESPONSE: dict[str, Any] = {
+    "570": {"appid": 570, "name": "Dota 2", "developer": "Valve", "ccu": 500000},
+    "730": {"appid": 730, "name": "Counter-Strike 2", "developer": "Valve", "ccu": 800000},
+    "440": {"appid": 440, "name": "Team Fortress 2", "developer": "Valve", "ccu": 100000},
+    "1172470": {
+        "appid": 1172470,
+        "name": "Apex Legends",
+        "developer": "Respawn",
+        "ccu": 300000,
+    },
+    "252490": {"appid": 252490, "name": "Rust", "developer": "Facepunch", "ccu": 90000},
+}
+
+_STEAM_SOURCE: dict[str, Any] = {
+    "id": "steam_top_games",
+    "enabled": True,
+    "type": "json",
+    "url": "https://steamspy.com/api.php",
+    "params": {"request": "top100in2weeks"},
+    "sort_by": "ccu",
+    "sort_reverse": True,
+    "limit": 3,
+    "sheet_tab": "steam_games",
+    "dedupe_key": "appid",
+    "fields": {
+        "title": "name",
+        "url": None,
+        "description": "developer",
+        "metric": "ccu",
+        "image_url": None,
+    },
+    "message_template": (
+        "<b>{title}</b>\nDeveloper: {description}\nPlayers: {metric}\n"
+        "https://store.steampowered.com/app/{appid}"
+    ),
+}
+
+_STEAM_CONFIG: dict[str, Any] = {"version": 1, "sources": [_STEAM_SOURCE]}
+
+
+class TestSteamPipeline(unittest.TestCase):
+    def test_steam_dict_of_dicts_extracted(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_STEAM_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_STEAM_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 3)
+        self.assertEqual(len(storage.stored_rows("steam_games")), 3)
+
+    def test_steam_sorted_by_ccu(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_STEAM_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_STEAM_CONFIG)
+
+        # appids sorted by ccu desc: 730 (800k), 570 (500k), 1172470 (300k)
+        stored_keys = [row[0] for row in storage.stored_rows("steam_games")]
+        self.assertEqual(stored_keys, ["730", "570", "1172470"])
+
+    def test_steam_url_built_from_appid(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_STEAM_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_STEAM_CONFIG)
+
+        text = notifier.sent[0].text
+        self.assertIn("https://store.steampowered.com/app/730", text)
+
+    def test_steam_missing_developer(self) -> None:
+        response = {
+            "99": {"appid": 99, "name": "Indie Game", "developer": "", "ccu": 50},
+        }
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(response):
+            run_json_pipeline(storage, notifier, sources_config=_STEAM_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 1)
+        self.assertIn("Indie Game", notifier.sent[0].text)
+
+    def test_steam_dedup_by_appid(self) -> None:
+        storage = InMemoryStorage()
+        storage._keys["steam_games"].add("730")
+        storage._keys["steam_games"].add("570")
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_STEAM_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_STEAM_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 1)
+        self.assertIn("Apex Legends", notifier.sent[0].text)
+
+
+class TestSorting(unittest.TestCase):
+    def test_sort_by_descending(self) -> None:
+        source = {**_GITHUB_SOURCE, "sort_by": "stargazers_count", "sort_reverse": True}
+        config: dict[str, Any] = {"version": 1, "sources": [source]}
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_GITHUB_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=config)
+
+        stored_keys = [row[0] for row in storage.stored_rows("github_projects")]
+        self.assertEqual(stored_keys, ["user/repo-alpha", "org/repo-beta", "dev/repo-gamma"])
+
+    def test_no_sort_by_preserves_order(self) -> None:
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+
+        with _patch_fetch(_GITHUB_RESPONSE):
+            run_json_pipeline(storage, notifier, sources_config=_CONFIG)
+
+        self.assertEqual(len(notifier.sent), 3)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Enables `steam_top_games` source using SteamSpy `top100in2weeks` endpoint
- Adds declarative `sort_by`/`sort_reverse` to `json_pipeline.py` for client-side sorting (SteamSpy returns unordered dict-of-dicts)
- Steam app URLs built via `{appid}` raw-field fallback in message template — zero new modules

## Key design points

| Decision | Rationale |
|----------|-----------|
| `sort_by: "ccu"` + `sort_reverse: true` | SteamSpy has no server-side sort; without this, `[:limit]` cuts arbitrary games |
| URL in template: `https://store.steampowered.com/app/{appid}` | Leverages raw-field fallback from #6 — no computed-field machinery needed |
| No `json_path` / no `headers` | SteamSpy returns flat dict-of-dicts (handled by `_unwrap_records(data, None)`) and needs no auth |
| Sheets URL column empty | Acceptable tradeoff for config-only approach; Telegram link is clickable |

## Files changed

| File | What |
|------|------|
| `json_pipeline.py` | +5 lines: `sort_by`/`sort_reverse` before extraction |
| `sources.json` | Enable steam, add sort config, update template |
| `tests/test_json_pipeline.py` | +7 tests: Steam extraction, sorting, dedup, null fields |

## Test plan

- [x] All 127 tests pass (`python scripts/ci_check.py`)
- [x] ruff format + lint clean
- [x] mypy strict — no errors
- [ ] Live test with SteamSpy API (manual)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)