### PR TITLE
feat(#8): update Action and README for declarative pipeline

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -8,18 +8,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-        
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: pip install -r requirements.txt
+        uses: actions/checkout@v4
 
-      - name: Run script
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run pure logic tests
+        run: python -m pytest tests/ -x --timeout=60
+
+      - name: Run JSON sources pipeline
+        run: python json_pipeline.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOP_LIMIT: ${{ vars.GITHUB_TOP_LIMIT }}
+          STEAM_TOP_LIMIT: ${{ vars.STEAM_TOP_LIMIT }}
+          SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.BOT_CHATID }}
+          CREDENTIALS: ${{ secrets.CREDENTIALS }}
+
+      - name: Run legacy Kinozal scraper
         run: python scraper.py
-        env: 
+        env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           BOT_CHATID: ${{ secrets.BOT_CHATID }}
           CREDENTIALS: ${{ secrets.CREDENTIALS }}

--- a/README.md
+++ b/README.md
@@ -1,30 +1,97 @@
 # kinozal_scraper
-The parser analyzes the top kinozal.tv according to the schedule and sends all new films to telegram
+
+Multi-source notification pipeline that monitors Kinozal, GitHub, and Steam for new content, deduplicates via Google Sheets, and sends alerts to Telegram.
+
+Runs daily at 04:00 UTC via GitHub Actions.
+
+## Sources
+
+| Source | Type | API | Sheets Tab | Dedupe Key |
+|--------|------|-----|------------|------------|
+| Kinozal top movies | HTML scraping | kinozal.tv | `movies` | Film title |
+| GitHub new popular repos | JSON | GitHub Search API | `github_projects` | `full_name` |
+| Steam top games | JSON | SteamSpy | `steam_games` | `appid` |
+
+> **Note on GitHub source**: This uses the official [Search API](https://docs.github.com/en/rest/search/search) with `created:>=<7 days ago>` sorted by stars. It finds *new popular repositories*, not the curated [github.com/trending](https://github.com/trending) list which uses undocumented ranking.
+
+## Architecture
+
+```
+sources.json          Declarative config (URLs, fields, limits, macros)
+pipeline_config.py    Load config, expand macros, validate schema
+json_pipeline.py      Generic runner for all JSON sources
+generic_pipeline.py   Pure extract/normalize functions (NormalizedItem)
+sheets_storage.py     Storage protocol (Google Sheets + InMemory)
+telegram_notifier.py  Notifier protocol (Telegram API + InMemory)
+kinozal_pipeline.py   Kinozal-specific runner (HTML, YouTube trailers)
+scraper.py            Legacy entry point (Kinozal + Telegram summarizer)
+```
+
+Adding a new JSON source requires only a config entry in `sources.json` — no Python code.
+
+## Configuration
+
+### GitHub Actions Variables (Settings > Variables > Actions)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GITHUB_TOP_LIMIT` | `10` | Number of GitHub repos to track |
+| `STEAM_TOP_LIMIT` | `10` | Number of Steam games to track |
+| `URLS` | — | Kinozal URLs (`label\|url;label\|url`) |
+| `LLM_MODEL` | — | Gemini model for Telegram summarizer |
+
+### Secrets (Settings > Secrets > Actions)
+
+| Secret | Used by |
+|--------|---------|
+| `GITHUB_TOKEN` | GitHub Search API auth (auto-provided) |
+| `BOT_TOKEN` | Telegram bot token |
+| `BOT_CHATID` | Telegram chat ID |
+| `CREDENTIALS` | Google service account JSON |
+| `SPREADSHEET_URL` | Google Sheets URL for deduplication |
+| `API_KEY` | YouTube Data API key |
+| `GOOGLE_API_KEY` | Gemini API key |
+
+Changing `GITHUB_TOP_LIMIT` or `STEAM_TOP_LIMIT` adjusts item count without code edits.
+
+## Failure behavior
+
+- **Test gate**: pure logic tests run before any production code. If tests fail, the workflow stops — no partial execution.
+- **JSON sources (at-least-once)**: notifications are sent before writing to Sheets. If Telegram fails, the item is NOT marked as seen and will retry on the next run. Possible duplicate notification on crash between send and store — acceptable tradeoff over silent data loss.
+- **Source isolation**: one source failing (network error, API down) does not block other sources.
+- **Kinozal (at-most-once)**: writes to Sheets before Telegram. Failed notifications are not retried.
+
+## Setup
+
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+git config core.hooksPath .githooks
+```
 
 ## Quality tooling
 
-Install production and development dependencies:
+Run the local quality gates:
 
 ```bash
-python -m pip install -r requirements.txt -r requirements-dev.txt
+python scripts/ci_check.py
 ```
 
-Run the local quality gates:
+Or individually:
 
 ```bash
 python -m ruff format --check .
 python -m ruff check .
 python -m pytest
+python -m mypy <modules>
 ```
 
-Run the advisory dependency audit:
+Dependency audit:
 
 ```bash
 python -m pip_audit -r requirements.txt
 ```
 
-Regenerate pinned dependency files after editing `requirements.in` or
-`requirements-dev.in`:
+Regenerate pinned dependencies:
 
 ```bash
 python -m piptools compile requirements.in --output-file requirements.txt --strip-extras --upgrade


### PR DESCRIPTION
## Summary

- Updates scheduled workflow to run tests before production and execute the new JSON pipeline
- Rewrites README with full pipeline documentation

## Workflow changes (`run-script.yml`)

1. **Test gate**: `pytest tests/ -x` runs first — fails fast before any production code
2. **JSON pipeline step**: `python json_pipeline.py` with `GITHUB_TOKEN`, `GITHUB_TOP_LIMIT`, `STEAM_TOP_LIMIT`
3. **Upgraded actions**: checkout v4, setup-python v5, pinned Python 3.12
4. **Legacy preserved**: `python scraper.py` still runs with all existing env vars

## README rewrite

- Source overview table (Kinozal, GitHub, Steam)
- Architecture diagram (layers)
- Full env vars / secrets / variables reference
- Failure behavior (at-least-once vs at-most-once, source isolation)
- Explicit note: GitHub Search API ≠ github.com/trending
- Quality tooling section preserved

## Setup required in GitHub UI

After merge, add these in **Settings > Variables > Actions**:
- `GITHUB_TOP_LIMIT` (default: 10)
- `STEAM_TOP_LIMIT` (default: 10)

And in **Settings > Secrets > Actions**:
- `SPREADSHEET_URL` — Google Sheets URL for deduplication

`GITHUB_TOKEN` is auto-provided by GitHub Actions.

## Test plan

- [x] YAML validates (`yaml.safe_load`)
- [x] All 127 tests pass
- [x] CI checks clean (ruff, mypy)
- [ ] Trigger `workflow_dispatch` after merge to verify end-to-end

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)