### PR TITLE
feat(#8): update Action and README for declarative pipeline

### DIFF
--- a/json_pipeline.py
+++ b/json_pipeline.py
@@ -102,6 +102,7 @@ def _run_single_source(source: dict[str, Any], storage: Storage, notifier: Notif
 
 
 if __name__ == "__main__":
+    import json
     import os
 
     import gspread
@@ -109,7 +110,7 @@ if __name__ == "__main__":
     from sheets_storage import SheetsStorage
     from telegram_notifier import TelegramNotifier
 
-    gc = gspread.service_account()
+    gc = gspread.service_account_from_dict(json.loads(os.environ["CREDENTIALS"]))
     prod_storage = SheetsStorage(gc, os.environ["SPREADSHEET_URL"])
     prod_notifier = TelegramNotifier(
         bot_token=os.environ["TELEGRAM_BOT_TOKEN"],


### PR DESCRIPTION
## Summary

- Workflow: test gate + json_pipeline step + upgraded actions + new env vars
- README: full pipeline documentation
- Fix: `gspread.service_account_from_dict` (matches `CREDENTIALS` env pattern used by scraper.py)

## Workflow changes

1. `pytest tests/ -x` runs before any production step
2. `python json_pipeline.py` with `GITHUB_TOKEN`, `GITHUB_TOP_LIMIT`, `STEAM_TOP_LIMIT`, `SPREADSHEET_URL`
3. `python scraper.py` unchanged (legacy Kinozal + Telegram summarizer)

## Setup required after merge

**New secret** (Settings → Secrets → Actions):
- `SPREADSHEET_URL` — URL Google Sheets для дедупликации

**New variables** (Settings → Variables → Actions):
- `GITHUB_TOP_LIMIT` — default `10`
- `STEAM_TOP_LIMIT` — default `10`

`GITHUB_TOKEN` создавать не нужно — GitHub предоставляет автоматически.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)