### PR TITLE
fix: rename GITHUB_TOP_LIMIT to GH_TOP_LIMIT

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -25,7 +25,7 @@ jobs:
         run: python json_pipeline.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOP_LIMIT: ${{ vars.GITHUB_TOP_LIMIT }}
+          GH_TOP_LIMIT: ${{ vars.GH_TOP_LIMIT }}
           STEAM_TOP_LIMIT: ${{ vars.STEAM_TOP_LIMIT }}
           SPREADSHEET_URL: ${{ secrets.SPREADSHEET_URL }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -39,7 +39,7 @@ def build_macro_context(
     return {
         "TODAY": today.isoformat(),
         "DATE_MINUS_7_DAYS": (today - timedelta(days=7)).isoformat(),
-        "GITHUB_TOP_LIMIT": env.get("GITHUB_TOP_LIMIT", "10"),
+        "GH_TOP_LIMIT": env.get("GH_TOP_LIMIT", "10"),
         "GITHUB_TOKEN": env.get("GITHUB_TOKEN", ""),
         "STEAM_TOP_LIMIT": env.get("STEAM_TOP_LIMIT", "10"),
         "KINOZAL_TOP_URL": env.get("KINOZAL_TOP_URL", ""),

--- a/sources.json
+++ b/sources.json
@@ -15,9 +15,9 @@
         "q": "created:>={{DATE_MINUS_7_DAYS}}",
         "sort": "stars",
         "order": "desc",
-        "per_page": "{{GITHUB_TOP_LIMIT}}"
+        "per_page": "{{GH_TOP_LIMIT}}"
       },
-      "limit": "{{GITHUB_TOP_LIMIT}}",
+      "limit": "{{GH_TOP_LIMIT}}",
       "sheet_tab": "github_projects",
       "dedupe_key": "full_name",
       "fields": {

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -42,14 +42,14 @@ class TestBuildMacroContext(unittest.TestCase):
 
     def test_env_macro_defaults(self) -> None:
         ctx = build_macro_context(today=date(2024, 1, 1), env={})
-        self.assertEqual(ctx["GITHUB_TOP_LIMIT"], "10")
+        self.assertEqual(ctx["GH_TOP_LIMIT"], "10")
         self.assertEqual(ctx["STEAM_TOP_LIMIT"], "10")
 
     def test_env_macro_overrides(self) -> None:
         ctx = build_macro_context(
-            today=date(2024, 1, 1), env={"GITHUB_TOP_LIMIT": "25", "STEAM_TOP_LIMIT": "50"}
+            today=date(2024, 1, 1), env={"GH_TOP_LIMIT": "25", "STEAM_TOP_LIMIT": "50"}
         )
-        self.assertEqual(ctx["GITHUB_TOP_LIMIT"], "25")
+        self.assertEqual(ctx["GH_TOP_LIMIT"], "25")
         self.assertEqual(ctx["STEAM_TOP_LIMIT"], "50")
 
 


### PR DESCRIPTION
GitHub reserves the `GITHUB_` prefix for built-in variables and blocks creating custom variables with that name.

Renamed `GITHUB_TOP_LIMIT` → `GH_TOP_LIMIT` in all locations:
- `pipeline_config.py`
- `sources.json`
- `.github/workflows/run-script.yml`
- `tests/test_pipeline_config.py`

Variable `GH_TOP_LIMIT = 10` already created in GitHub Actions Variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)