### PR TITLE
fix: remove --timeout flag from pytest (not in prod deps)

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -19,7 +19,7 @@ jobs:
         run: pip install -r requirements.txt -r requirements-dev.txt
 
       - name: Run pure logic tests
-        run: python -m pytest tests/ -x --timeout=60
+        run: python -m pytest tests/ -x
 
       - name: Run JSON sources pipeline
         run: python json_pipeline.py


### PR DESCRIPTION
`--timeout=60` requires `pytest-timeout` which is a dev dependency not installed in production. Removes the flag — tests still run with `-x` (fail fast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)