### PR TITLE
fix: add GOOGLE_API_KEY and LLM_MODEL to json_pipeline step

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -31,6 +31,8 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.BOT_CHATID }}
           CREDENTIALS: ${{ secrets.CREDENTIALS }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
 
       - name: Run legacy Kinozal scraper
         run: python scraper.py


### PR DESCRIPTION
## Summary
- Adds `GOOGLE_API_KEY` and `LLM_MODEL` env vars to the "Run JSON sources pipeline" workflow step
- Without them, `json_pipeline.py` always uses `NullEnricher` and GitHub repo descriptions are never generated

## Test plan
- [x] CI passes
- [ ] Trigger workflow_dispatch and verify Gemini enrichment runs (or gracefully falls back if quota exhausted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)