### PR TITLE
fix: filter model list to text-generation Gemini models only

### DIFF
--- a/gemini_enricher.py
+++ b/gemini_enricher.py
@@ -89,13 +89,23 @@ def _model_version_key(name: str) -> tuple[float, str]:
     return (0.0, name)
 
 
+_EXCLUDED_SUFFIXES = ("-tts", "-image", "-customtools", "-computer-use", "-robotics")
+
+
+def _is_text_gemini(name: str) -> bool:
+    """Filter to pure text-generation Gemini models only."""
+    if not name.startswith("models/gemini-"):
+        return False
+    return not any(s in name for s in _EXCLUDED_SUFFIXES)
+
+
 def get_generation_models() -> list[str]:
-    """Return model names with generateContent support, newer versions first."""
+    """Return text-generation Gemini model names, newer versions first."""
     try:
         names = [
             m.name
             for m in genai.list_models()
-            if "generateContent" in m.supported_generation_methods
+            if "generateContent" in m.supported_generation_methods and _is_text_gemini(m.name)
         ]
     except Exception:
         logger.warning("cannot list models")

--- a/tests/test_gemini_enricher.py
+++ b/tests/test_gemini_enricher.py
@@ -106,6 +106,32 @@ class TestModelVersionSorting(unittest.TestCase):
         self.assertEqual(_model_version_key("models/chat-bison-001")[0], 0.0)
 
 
+class TestIsTextGemini(unittest.TestCase):
+    def test_accepts_text_models(self) -> None:
+        from gemini_enricher import _is_text_gemini
+
+        self.assertTrue(_is_text_gemini("models/gemini-2.5-flash"))
+        self.assertTrue(_is_text_gemini("models/gemini-2.0-flash-lite"))
+        self.assertTrue(_is_text_gemini("models/gemini-3.1-pro-preview"))
+        self.assertTrue(_is_text_gemini("models/gemini-2.5-flash-lite"))
+
+    def test_rejects_specialized_models(self) -> None:
+        from gemini_enricher import _is_text_gemini
+
+        self.assertFalse(_is_text_gemini("models/gemini-3.1-flash-tts-preview"))
+        self.assertFalse(_is_text_gemini("models/gemini-3.1-flash-image-preview"))
+        self.assertFalse(_is_text_gemini("models/gemini-3.1-pro-preview-customtools"))
+        self.assertFalse(_is_text_gemini("models/gemini-2.5-computer-use-preview-10-2025"))
+        self.assertFalse(_is_text_gemini("models/gemini-robotics-er-1.6-preview"))
+
+    def test_rejects_non_gemini(self) -> None:
+        from gemini_enricher import _is_text_gemini
+
+        self.assertFalse(_is_text_gemini("models/gemma-3-27b-it"))
+        self.assertFalse(_is_text_gemini("models/lyria-3-pro-preview"))
+        self.assertFalse(_is_text_gemini("models/nano-banana-pro-preview"))
+
+
 class TestRotatingGeminiEnricher(unittest.TestCase):
     def test_implements_enricher_protocol(self) -> None:
         self.assertIsInstance(RotatingGeminiEnricher(["m1"]), Enricher)


### PR DESCRIPTION
## Summary
- Filters `get_generation_models()` to only include text-generation Gemini models
- Excludes: TTS (`-tts`), image (`-image`), robotics (`-robotics`), computer-use (`-computer-use`), custom tools (`-customtools`)
- Excludes non-Gemini families: gemma, lyria, nano
- These models support `generateContent` but return 400 errors on text prompts

## Context
PR #28 merge lost this commit during squash. Without this filter, the model list included ~30 models, many of which fail with `400 Request contains an invalid argument`.

## Test plan
- [x] `_is_text_gemini` accepts `gemini-2.5-flash`, `gemini-2.0-flash-lite`, `gemini-3.1-pro-preview`
- [x] Rejects TTS, image, robotics, computer-use, customtools models
- [x] Rejects gemma, lyria, nano families
- [x] 151 tests pass, ruff/mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)