### PR TITLE
feat: switch GitHub query to trending-style (30d window, stars>1000)

### DIFF
--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -39,6 +39,7 @@ def build_macro_context(
     return {
         "TODAY": today.isoformat(),
         "DATE_MINUS_7_DAYS": (today - timedelta(days=7)).isoformat(),
+        "DATE_MINUS_30_DAYS": (today - timedelta(days=30)).isoformat(),
         "GH_TOP_LIMIT": env.get("GH_TOP_LIMIT", "10"),
         "GITHUB_TOKEN": env.get("GITHUB_TOKEN", ""),
         "STEAM_TOP_LIMIT": env.get("STEAM_TOP_LIMIT", "10"),

--- a/pipeline_config.py
+++ b/pipeline_config.py
@@ -38,7 +38,6 @@ def build_macro_context(
 
     return {
         "TODAY": today.isoformat(),
-        "DATE_MINUS_7_DAYS": (today - timedelta(days=7)).isoformat(),
         "DATE_MINUS_30_DAYS": (today - timedelta(days=30)).isoformat(),
         "GH_TOP_LIMIT": env.get("GH_TOP_LIMIT", "10"),
         "GITHUB_TOKEN": env.get("GITHUB_TOKEN", ""),

--- a/sources.json
+++ b/sources.json
@@ -12,7 +12,7 @@
         "Authorization": "Bearer {{GITHUB_TOKEN}}"
       },
       "params": {
-        "q": "created:>={{DATE_MINUS_7_DAYS}}",
+        "q": "created:>={{DATE_MINUS_30_DAYS}} stars:>1000",
         "sort": "stars",
         "order": "desc",
         "per_page": "{{GH_TOP_LIMIT}}"

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -39,6 +39,7 @@ class TestBuildMacroContext(unittest.TestCase):
         ctx = build_macro_context(today=date(2024, 3, 15))
         self.assertEqual(ctx["TODAY"], "2024-03-15")
         self.assertEqual(ctx["DATE_MINUS_7_DAYS"], "2024-03-08")
+        self.assertEqual(ctx["DATE_MINUS_30_DAYS"], "2024-02-14")
 
     def test_env_macro_defaults(self) -> None:
         ctx = build_macro_context(today=date(2024, 1, 1), env={})

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -38,7 +38,6 @@ class TestBuildMacroContext(unittest.TestCase):
     def test_date_macros_iso_format(self) -> None:
         ctx = build_macro_context(today=date(2024, 3, 15))
         self.assertEqual(ctx["TODAY"], "2024-03-15")
-        self.assertEqual(ctx["DATE_MINUS_7_DAYS"], "2024-03-08")
         self.assertEqual(ctx["DATE_MINUS_30_DAYS"], "2024-02-14")
 
     def test_env_macro_defaults(self) -> None:
@@ -128,7 +127,7 @@ class TestLoadSourcesConfig(unittest.TestCase):
         self.assertEqual(len(config["sources"]), 1)
 
     def test_macro_expansion_in_url(self) -> None:
-        source = {**_MINIMAL_SOURCE, "url": "https://api.example.com?since={{DATE_MINUS_7_DAYS}}"}
+        source = {**_MINIMAL_SOURCE, "url": "https://api.example.com?since={{DATE_MINUS_30_DAYS}}"}
         path = _write_tmp(_make_config([source]))
         config = load_sources_config(path)
         url = config["sources"][0]["url"]


### PR DESCRIPTION
## Summary
- Changed query from `created:>={{DATE_MINUS_7_DAYS}}` to `created:>={{DATE_MINUS_30_DAYS}} stars:>1000`
- Added `DATE_MINUS_30_DAYS` macro to `pipeline_config.py`
- Threshold `stars:>1000` отсекает мусор — только проекты которые реально "выстрелили"

## Логика
Новый запрос: репозитории созданные за последние 30 дней с 1000+ звёзд, отсортированные по stars desc. Если проект набрал 1000+ звёзд за первый месяц — он вирусный по определению. Дедупликация через Google Sheets гарантирует что один и тот же репо не придёт дважды.

## Test plan
- [x] `DATE_MINUS_30_DAYS` тест в `test_pipeline_config.py`
- [x] 151 тест проходит

🤖 Generated with [Claude Code](https://claude.com/claude-code)