### PR TITLE
feat: improve YouTube trailer search accuracy

### DIFF
--- a/kinozal_pipeline.py
+++ b/kinozal_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 import requests
@@ -52,7 +53,9 @@ def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
     """Clean title and look up a YouTube trailer URL. Returns '' on any failure."""
     try:
         clean = item.title.split("/")[0].strip().split("(")[0].strip()
-        return youtube.get_trailer_url(clean) or ""
+        year_match = re.search(r"\b(20\d{2})\b", item.title)
+        year = int(year_match.group(1)) if year_match else None
+        return youtube.get_trailer_url(clean, year=year) or ""
     except Exception as exc:
         logger.error("trailer lookup failed for %r: %s", item.title, exc)
         return ""

--- a/scraper.py
+++ b/scraper.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from datetime import datetime
+from datetime import date, datetime, timedelta
 import requests
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -104,13 +104,28 @@ class Youtube:
         self.credentials = os.environ['API_KEY']
         self.youtube = build('youtube', 'v3', developerKey=self.credentials)
 
-    def get_trailer_url(self, film):
+    def get_trailer_url(self, film, year=None):
         """Получает URL трейлера фильма."""
-        request = self.youtube.search().list(q=f"{film} trailer", part='id', maxResults=5)
-        response = request.execute()
-        for item in response['items']:
+        query = f"{film} {year} trailer" if year else f"{film} trailer"
+        if year:
+            published_after = f"{year}-01-01T00:00:00Z"
+        else:
+            cutoff = date.today() - timedelta(days=180)
+            published_after = f"{cutoff.isoformat()}T00:00:00Z"
+        result = self._search_youtube(query, published_after)
+        if result:
+            return result
+        return self._search_youtube(query, published_after=None)
+
+    def _search_youtube(self, query, published_after=None):
+        """Выполняет поиск на YouTube и возвращает URL первого подходящего видео."""
+        params = dict(q=query, part='id', maxResults=5, type='video', videoDuration='short')
+        if published_after:
+            params['publishedAfter'] = published_after
+        response = self.youtube.search().list(**params).execute()
+        for item in response.get('items', []):
             if item['id'].get('kind') == 'youtube#video':
-                return f"https://www.youtube.com/watch?v={item['id'].get('videoId')}"
+                return f"https://www.youtube.com/watch?v={item['id']['videoId']}"
         return None
 
 class TelegramBot:

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -41,12 +41,18 @@ _SOURCES_CONFIG = {"version": 1, "sources": [_KINOZAL_SOURCE]}
 
 
 class _FakeYoutube:
-    def get_trailer_url(self, film: str) -> str:
+    def __init__(self) -> None:
+        self.last_film: str = ""
+        self.last_year: int | None = None
+
+    def get_trailer_url(self, film: str, year: int | None = None) -> str:
+        self.last_film = film
+        self.last_year = year
         return f"https://youtube.com/watch?v={film.replace(' ', '_')}"
 
 
 class _RaisingYoutube:
-    def get_trailer_url(self, film: str) -> str:
+    def get_trailer_url(self, film: str, year: int | None = None) -> str:
         raise RuntimeError("YouTube API down")
 
 
@@ -105,6 +111,30 @@ class TestEnrichWithTrailer(unittest.TestCase):
         item = self._item("Some Film")
         trailer = enrich_with_trailer(item, _RaisingYoutube())
         self.assertEqual(trailer, "")
+
+    def test_year_extracted_from_title_and_passed(self) -> None:
+        youtube = _FakeYoutube()
+        item = self._item("Film One / 2024 / BDRip")
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_year, 2024)
+
+    def test_no_year_passes_none(self) -> None:
+        youtube = _FakeYoutube()
+        item = self._item("Film Without Year")
+        enrich_with_trailer(item, youtube)
+        self.assertIsNone(youtube.last_year)
+
+    def test_year_in_parentheses_extracted(self) -> None:
+        youtube = _FakeYoutube()
+        item = self._item("Film (2023)")
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_year, 2023)
+
+    def test_clean_title_passed_without_year_slash(self) -> None:
+        youtube = _FakeYoutube()
+        item = self._item("Great Film / 2025 / WEB-DL")
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_film, "Great Film")
 
 
 # ── _kinozal_urls ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Год извлекается из `item.title` (`"Film / 2024 / BDRip"` → `2024`) и передаётся в `get_trailer_url(year=2024)`
- Поисковый запрос: `"Film 2024 trailer"` вместо `"Film trailer"`
- `publishedAfter` = `{year}-01-01` (или 6 месяцев назад если год не найден) — отсекает старые трейлеры
- `videoDuration='short'` — < 4 мин, соответствует реальной длине трейлеров
- `type='video'` — явно на уровне API вместо Python-фильтра
- Fallback: если с фильтром по дате ноль результатов — повторный запрос без даты

## Test plan

- [x] `python scripts/ci_check.py` — 171 тест, ruff + mypy чисто
- [ ] Запустить workflow вручную, проверить что трейлеры соответствуют фильмам

🤖 Generated with [Claude Code](https://claude.com/claude-code)