### PR TITLE
feat: filter YouTube trailers by year in video title (#35)

### DIFF
--- a/kinozal_pipeline.py
+++ b/kinozal_pipeline.py
@@ -49,6 +49,12 @@ def _kinozal_urls() -> list[str]:
     return [fallback] if fallback else []
 
 
+def _title_year_matches(title: str, film_year: int) -> bool:
+    """Return False if the video title explicitly mentions a year other than film_year."""
+    title_years = {int(m) for m in re.findall(r"\b((?:19|20)\d{2})\b", title)}
+    return not title_years or film_year in title_years
+
+
 def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
     """Clean title and look up a YouTube trailer URL. Returns '' on any failure."""
     try:

--- a/scraper.py
+++ b/scraper.py
@@ -112,20 +112,26 @@ class Youtube:
         else:
             cutoff = date.today() - timedelta(days=180)
             published_after = f"{cutoff.isoformat()}T00:00:00Z"
-        result = self._search_youtube(query, published_after)
+        result = self._search_youtube(query, published_after, film_year=year)
         if result:
             return result
-        return self._search_youtube(query, published_after=None)
+        return self._search_youtube(query, published_after=None, film_year=year)
 
-    def _search_youtube(self, query, published_after=None):
+    def _search_youtube(self, query, published_after=None, film_year=None):
         """Выполняет поиск на YouTube и возвращает URL первого подходящего видео."""
-        params = dict(q=query, part='id', maxResults=5, type='video', videoDuration='short')
+        params = dict(q=query, part='id,snippet', maxResults=5, type='video', videoDuration='short')
         if published_after:
             params['publishedAfter'] = published_after
         response = self.youtube.search().list(**params).execute()
+        from kinozal_pipeline import _title_year_matches
         for item in response.get('items', []):
-            if item['id'].get('kind') == 'youtube#video':
-                return f"https://www.youtube.com/watch?v={item['id']['videoId']}"
+            if item['id'].get('kind') != 'youtube#video':
+                continue
+            if film_year:
+                title = item.get('snippet', {}).get('title', '')
+                if not _title_year_matches(title, film_year):
+                    continue
+            return f"https://www.youtube.com/watch?v={item['id']['videoId']}"
         return None
 
 class TelegramBot:

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -3,7 +3,7 @@ import unittest.mock
 from typing import Any
 
 from generic_pipeline import ROW_HEADERS, NormalizedItem, Notification, extract_from_html
-from kinozal_pipeline import _kinozal_urls, enrich_with_trailer
+from kinozal_pipeline import _kinozal_urls, _title_year_matches, enrich_with_trailer
 from sheets_storage import InMemoryStorage
 from telegram_notifier import InMemoryNotifier
 
@@ -135,6 +135,28 @@ class TestEnrichWithTrailer(unittest.TestCase):
         item = self._item("Great Film / 2025 / WEB-DL")
         enrich_with_trailer(item, youtube)
         self.assertEqual(youtube.last_film, "Great Film")
+
+
+# ── _title_year_matches ───────────────────────────────────────────────────────
+
+
+class TestTitleYearMatches(unittest.TestCase):
+    def test_matching_year_accepted(self) -> None:
+        self.assertTrue(_title_year_matches("Great Film 2026 Official Trailer", 2026))
+
+    def test_wrong_year_rejected(self) -> None:
+        self.assertFalse(
+            _title_year_matches("Kingsman: Секретная служба (2015) Трейлер на русском", 2026)
+        )
+
+    def test_no_year_in_title_accepted(self) -> None:
+        self.assertTrue(_title_year_matches("Секретная служба трейлер", 2026))
+
+    def test_multiple_years_one_matches(self) -> None:
+        self.assertTrue(_title_year_matches("Film 2025/2026 Official Trailer", 2026))
+
+    def test_multiple_years_none_match(self) -> None:
+        self.assertFalse(_title_year_matches("Remake 2023 vs Original 2015", 2026))
 
 
 # ── _kinozal_urls ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes wrong trailers matching films with the same Russian title but different release years (e.g. 2015 Kingsman trailer matching a 2026 film search)
- Adds `_title_year_matches()` helper in `kinozal_pipeline.py` — returns `False` if the video title explicitly mentions a year other than the film's year
- `scraper.py` `_search_youtube()` now fetches `part='id,snippet'` and applies year-mismatch filtering per video result
- Year extracted from Kinozal title (e.g. `"Film One / 2024 / BDRip"`) and passed through `get_trailer_url()` → `publishedAfter` + title filter
- Fallback search without `publishedAfter` still applies year-title filter

## Test plan

- [x] `TestTitleYearMatches` — 5 unit tests for `_title_year_matches()` covering matching year, wrong year, no year, multiple years
- [x] `TestEnrichWithTrailer` — 7 tests covering title cleaning, year extraction from slash-format and parentheses format, exception handling
- [x] All 176 tests pass (`python scripts/ci_check.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)