### PR TITLE
fix: bump urllib3 to 2.7.0 (CVE-2026-44431, CVE-2026-44432)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -137,7 +137,7 @@ typing-extensions==4.15.0
     # via
     #   cyclonedx-python-lib
     #   mypy
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   requests
     #   types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -186,7 +186,7 @@ tzdata==2026.2
     # via pandas
 uritemplate==4.2.0
     # via google-api-python-client
-urllib3[socks]==2.6.3
+urllib3[socks]==2.7.0
     # via
     #   requests
     #   selenium


### PR DESCRIPTION
## Summary

- Bumps `urllib3` from 2.6.3 to 2.7.0 to fix two known vulnerabilities
- CVE-2026-44431 and CVE-2026-44432, both fixed in 2.7.0

## Test plan

- [ ] CI dependency audit passes (`pip_audit` no longer reports vulnerabilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)