### PR TITLE
ci: auto-run Claude code-review on every PR (closes #70)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,45 @@
+name: Claude code review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request as a senior engineer would. Read CLAUDE.md
+            first — it lists project conventions that take precedence over your
+            defaults.
+
+            Focus on:
+            - Bugs and logic errors
+            - Security issues
+            - Adherence to the conventions in CLAUDE.md (PR workflow, branch
+              naming, dependency rules, no workarounds without root cause)
+            - Whether the change has matching test coverage and whether
+              `docs/architecture/test-coverage.md` is updated when test
+              structure changes
+
+            Skip nitpicks — ruff handles formatting/lint. Skip docstring style
+            and small wording issues unless they obscure intent.
+
+            Leave findings as inline PR review comments at the relevant lines.
+            If the PR looks clean, post a single top-level comment saying so
+            explicitly. Do not approve or merge — those stay with the human
+            reviewer.

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -21,6 +21,24 @@ Steps: checkout → Python 3.12 → install deps → ruff format → ruff lint �
 
 mypy excludes the same legacy files as `ci_check.py`, plus `.claude` directory.
 
+## Claude review workflow (`claude-review.yml`)
+
+Triggers: every `pull_request: opened/synchronize`.
+
+Uses `anthropics/claude-code-action@v1` to run an automated code review on
+every PR push. Posts inline comments at relevant lines and a top-level
+verdict. Does **not** approve or merge — human reviewer keeps that.
+
+### One-time setup
+
+1. Locally: `claude setup-token` (requires Claude Pro/Max subscription) → copy the token.
+2. Repo Settings → Secrets and variables → Actions → New repository secret:
+   - Name: `CLAUDE_CODE_OAUTH_TOKEN`
+   - Value: the token from step 1.
+3. The workflow consumes it via `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` passed as the action's `anthropic_api_key` input (input name is legacy — token format is what matters).
+
+No separate Anthropic API billing — usage counts against the Pro/Max subscription quota.
+
 ## Production workflow (`run-script.yml`)
 
 Schedule: `0 4 * * *` UTC + manual `workflow_dispatch`.


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/claude-review.yml`:
  - Triggers on `pull_request: [opened, synchronize]`
  - Uses `anthropics/claude-code-action@v1`
  - Prompt: focused review (bugs, security, CLAUDE.md conventions, test-coverage doc updates) — skips ruff-handled nitpicks
  - Permissions: `contents: read`, `pull-requests: write`, `issues: read`
  - Auth: `CLAUDE_CODE_OAUTH_TOKEN` (Pro subscription, no per-token API billing)
- Documents the one-time setup in `docs/architecture/ci.md`: `claude setup-token` → add as repo secret `CLAUDE_CODE_OAUTH_TOKEN`.

This PR itself will be the first one reviewed by the new workflow — once the secret is set up.

## Required user action before merge
1. Run `claude setup-token` locally (Pro subscription required).
2. Repo Settings → Secrets and variables → Actions → New secret:
   - Name: `CLAUDE_CODE_OAUTH_TOKEN`
   - Value: token from step 1.
3. Re-run the failed workflow on this PR (Actions tab → claude-review → Re-run).

Closes #70.

## Test plan
- [x] `python scripts/ci_check.py` — all checks passed (workflow file does not affect Python checks)
- [ ] After secret is set + workflow re-runs: review comments should appear on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)