### PR TITLE
fix(claude-review): add id-token: write for OIDC auth

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  id-token: write
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- `anthropics/claude-code-action@v1` падал на каждом PR с `Could not fetch an OIDC token. Did you remember to add \`id-token: write\`...` — action использует OIDC для GitHub App auth даже с OAuth токеном из Pro/Max.
- Добавлен `id-token: write` в `permissions:` блок `.github/workflows/claude-review.yml`. Scope-minimal — даёт workflow только право запрашивать OIDC-токен, не расширяет доступ к репозиторию.

Closes #74.

## Test plan
- [ ] После мёрджа этого PR следующий PR должен пройти Claude review без ошибки OIDC
- [ ] (Этот PR сам по себе ещё упадёт на review — он же ту самую сломанную версию workflow и использует; нормально, это не блокирующий чек)

🤖 Generated with [Claude Code](https://claude.com/claude-code)