### PR TITLE
fix(claude-review): use claude_code_oauth_token input for OAuth token

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Review this pull request as a senior engineer would. Read CLAUDE.md
             first — it lists project conventions that take precedence over your

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -35,7 +35,9 @@ verdict. Does **not** approve or merge — human reviewer keeps that.
 2. Repo Settings → Secrets and variables → Actions → New repository secret:
    - Name: `CLAUDE_CODE_OAUTH_TOKEN`
    - Value: the token from step 1.
-3. The workflow consumes it via `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` passed as the action's `anthropic_api_key` input (input name is legacy — token format is what matters).
+3. The workflow consumes it via `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` passed as the action's `claude_code_oauth_token` input (separate from `anthropic_api_key`; OAuth tokens do not work as API keys).
+
+The workflow also needs `id-token: write` in `permissions:` — `anthropics/claude-code-action@v1` uses OIDC for GitHub App auth, and without that scope every run fails with "Could not fetch an OIDC token".
 
 No separate Anthropic API billing — usage counts against the Pro/Max subscription quota.
 


### PR DESCRIPTION
## Summary
- `anthropics/claude-code-action@v1` определяет два разных input: `anthropic_api_key` (для Anthropic API key формата `sk-ant-api03-...`) и `claude_code_oauth_token` (для OAuth токенов формата `sk-ant-oat01-...`). В #71 я ошибочно использовал первый для OAuth токена.
- После #75 OIDC прошёл, и обнажилась эта ошибка: SDK получает 401 «Invalid API key».
- Переключение на правильный input + актуализация `docs/architecture/ci.md` (убрать комментарий «input name is legacy», задокументировать `id-token: write`).

Closes #76.

## Test plan
- [ ] После мёрджа следующий PR (или re-trigger существующего синхронизацией) должен пройти review успешно — никаких OIDC и API key ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)