### PR TITLE
feat(claude-review): enable use_sticky_comment for visible review signal

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,6 +23,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
           prompt: |
             Review this pull request as a senior engineer would. Read CLAUDE.md
             first — it lists project conventions that take precedence over your

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -29,6 +29,12 @@ Uses `anthropics/claude-code-action@v1` to run an automated code review on
 every PR push. Posts inline comments at relevant lines and a top-level
 verdict. Does **not** approve or merge — human reviewer keeps that.
 
+`use_sticky_comment: true` is set so every run posts (or updates) a single
+pinned summary comment on the PR — without it, a run that finds no issues
+silently leaves the PR with no comment, making "review clean" and "review
+silently broken" indistinguishable. The sticky comment is updated in
+place on each push, not duplicated.
+
 ### One-time setup
 
 1. Locally: `claude setup-token` (requires Claude Pro/Max subscription) → copy the token.


### PR DESCRIPTION
## Summary
- Включает `use_sticky_comment: true` для `anthropics/claude-code-action@v1` в `.github/workflows/claude-review.yml`.
- Action будет создавать/обновлять один pinned PR-comment на каждом запуске — даже когда Claude не нашёл inline проблем. Это устраняет неразличимость между «review чистый» и «review silently broken» (см. run 25994516264 на PR #73 — `is_error: false`, 5 turns, 8.5s работы, но ни одного коммента на PR).
- Обновлена `docs/architecture/ci.md` с объяснением мотивации.

Closes #78. Следствие memory-принципа `feedback-visibility-over-silence` (см. #56).

## Test plan
- [ ] На этом PR (после открытия) появляется один Claude-comment с сводкой
- [ ] Push следующего коммита в эту же ветку обновляет тот же коммент, не дублирует
- [ ] При наличии реальных issues inline-комментарии продолжают появляться отдельно

🤖 Generated with [Claude Code](https://claude.com/claude-code)