### PR TITLE
fix(claude-review): switch to track_progress + explicit publish prompt

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,8 +23,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_sticky_comment: true
+          track_progress: true
+          show_full_output: true
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request as a senior engineer would. Read CLAUDE.md
             first — it lists project conventions that take precedence over your
             defaults.
@@ -41,7 +45,13 @@ jobs:
             Skip nitpicks — ruff handles formatting/lint. Skip docstring style
             and small wording issues unless they obscure intent.
 
-            Leave findings as inline PR review comments at the relevant lines.
-            If the PR looks clean, post a single top-level comment saying so
-            explicitly. Do not approve or merge — those stay with the human
-            reviewer.
+            How to deliver feedback:
+            - For each issue found: call `mcp__github_inline_comment__create_inline_comment`
+              at the relevant line.
+            - Always finish by posting a top-level summary via
+              `Bash(gh pr comment $PR_NUMBER --repo $REPO --body "...")`.
+              If no blocking issues, post exactly: "✅ Review complete — no
+              blocking issues found." This is mandatory: a silent finish is
+              indistinguishable from a broken review and is not acceptable.
+
+            Do not approve or merge — those stay with the human reviewer.

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -29,11 +29,23 @@ Uses `anthropics/claude-code-action@v1` to run an automated code review on
 every PR push. Posts inline comments at relevant lines and a top-level
 verdict. Does **not** approve or merge — human reviewer keeps that.
 
-`use_sticky_comment: true` is set so every run posts (or updates) a single
-pinned summary comment on the PR — without it, a run that finds no issues
-silently leaves the PR with no comment, making "review clean" and "review
-silently broken" indistinguishable. The sticky comment is updated in
-place on each push, not duplicated.
+Visibility is guaranteed via two layers:
+
+- `track_progress: true` — the action itself posts a tracking comment on
+  the PR at start ("Claude Code is reviewing…") and updates it as the
+  run proceeds. Independent of whatever Claude does, this guarantees at
+  least one visible signal that the review ran.
+- The prompt instructs Claude to (a) post per-issue inline comments via
+  `mcp__github_inline_comment__create_inline_comment` and (b) finish
+  with a top-level summary via `Bash(gh pr comment ...)`. The earlier
+  approach (`use_sticky_comment: true`) only controlled comment
+  *format*, not whether Claude published anything — when Claude found no
+  issues and didn't invoke a publishing tool, the PR stayed silent.
+
+`show_full_output: true` is enabled while we're stabilising review
+behaviour — full SDK transcript appears in Actions logs. Remove once
+the loop is reliable; it adds noise and may surface internal model
+chatter.
 
 ### One-time setup
 


### PR DESCRIPTION
## Summary
- Заменил `use_sticky_comment: true` (управлял только форматом) на `track_progress: true` (action **сам** публикует tracking-комментарий при старте и апдейтит его) — гарантия видимого сигнала независимо от поведения Claude.
- Усилил промпт: явно назвал MCP tool для inline (`mcp__github_inline_comment__create_inline_comment`) и обязал финальный `Bash(gh pr comment)` с явным «no issues» сообщением. Silent finish в промпте назван неприемлемым.
- Включил `show_full_output: true` для диагностики; убрать после стабилизации.
- Обновил `docs/architecture/ci.md` с объяснением layered visibility (action layer + prompt layer).

Closes #80.

## Test plan
- [ ] **На самом этом PR review не запустится** (workflow file changed — GitHub App validation: см. #75, #77, #79 — это нормально, известное ограничение). После мёрджа следующий PR — реальный тест.
- [ ] На следующем PR появляется tracking-комментарий **сразу** при старте action (от `track_progress`)
- [ ] К концу review-а коммент содержит сводку (либо инлайны + сводка, либо только «✅ Review complete — no blocking issues found»)
- [ ] `show_full_output: true` показывает в Actions logs полный transcript — можно посмотреть какие tools Claude реально вызывает

## Дальнейшее (после успеха)
- Если работает — отдельный PR убирает `show_full_output: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)