### PR TITLE
test: taxonomy coverage for Telegram summarizer + crypto (refs #45 PR2/3)

### DIFF
--- a/docs/architecture/test-coverage.md
+++ b/docs/architecture/test-coverage.md
@@ -18,12 +18,12 @@ category, add it here AND in `testing.md` taxonomy.
 |---|---|---|
 | A. Structure drift | `test_e2e_kinozal_titles.py::TestKinozalTitlesE2E` (kinozal HTML, real HTTP); `test_e2e_github_trending.py::TestGitHubTrendingE2E` (github trending HTML, real HTTP); `test_github_trending_pipeline.py::TestUS3Visibility` (zero-row → exit 1) | ⚠ partial — no E2E for GitHub `new_popular`/Steam JSON; new pipeline turns zero-row drift into red CI |
 | B. Network failures | `test_telegram_notifier.py::TestTelegramNotifierRetry::test_connection_error_goes_to_failed`, `test_429_*`, `TestTelegramNotifierKnownBugs::test_session_post_called_with_explicit_timeout`, `test_requests_timeout_routes_to_failed` | ✅ — Telegram `session.post` now passes `timeout=30` ([#54](https://github.com/ekolvah/kinozal_scraper/issues/54)); kinozal/GitHub/Steam HTTP timeouts already set to 30s in their `_fetch_*` |
-| C. Auth & quota | `test_gemini_enricher.py::TestGeminiEnricherQuota`, `TestRotatingGeminiEnricher::test_rotates_to_next_model_on_quota`, `test_all_models_exhausted_*`; `test_json_pipeline.py::TestEnricherQuotaCircuitBreaker::test_all_models_exhausted_from_start_uses_on_error_fallback`; `test_telegram_notifier.py::test_http_400_goes_to_failed`; `test_sheets_storage.py::TestSheetsStorageRetryOn429` (`test_429_then_success_retries_and_succeeds`, `test_429_repeated_eventually_raises_after_5_attempts`, `test_non_429_api_error_not_retried`) | ✅ — Sheets 429 retried with exponential backoff (5 attempts, 1s→60s) ([#55](https://github.com/ekolvah/kinozal_scraper/issues/55)); Gemini all-exhausted covered caller-side; no GitHub 401 |
+| C. Auth & quota | `test_gemini_enricher.py::TestGeminiEnricherQuota`, `TestRotatingGeminiEnricher::test_rotates_to_next_model_on_quota`, `test_all_models_exhausted_*`; `test_json_pipeline.py::TestEnricherQuotaCircuitBreaker::test_all_models_exhausted_from_start_uses_on_error_fallback`; `test_telegram_notifier.py::test_http_400_goes_to_failed`; `test_sheets_storage.py::TestSheetsStorageRetryOn429` (`test_429_then_success_retries_and_succeeds`, `test_429_repeated_eventually_raises_after_5_attempts`, `test_non_429_api_error_not_retried`); `test_telegram_summarizer.py::TestGeminiSummarizerQuota`, `TestTelethonReaderErrorSwallow::test_fetch_channel_swallows_exception_returns_error_tuple` | ✅ — Sheets 429 retried with exponential backoff (5 attempts, 1s→60s) ([#55](https://github.com/ekolvah/kinozal_scraper/issues/55)); Gemini all-exhausted covered caller-side; Telethon-session-expired surfaces as `(None, "", False)` swallow ([#45](https://github.com/ekolvah/kinozal_scraper/issues/45)); no GitHub 401 |
 | D. Config errors | `test_pipeline_config.py::TestValidateSourcesConfig`, `TestExpandMacros`, `TestBuildMacroContext`, `TestLoadSourcesConfig` (incl. `test_unresolved_macro_in_url_raises_config_error`, `test_unresolved_macro_in_nested_field_raises`), `TestConfigValidationKnownGaps::test_invalid_css_row_selector_not_caught_by_validator` | ⚠ documents-current-bug — invalid CSS `row_selector` not caught ([#57](https://github.com/ekolvah/kinozal_scraper/issues/57)); unresolved `{{macro}}` now raises `ConfigError` at load time ([#58](https://github.com/ekolvah/kinozal_scraper/issues/58)) |
 | E. Data integrity | `test_json_pipeline.py::TestJsonPipelineDeduplication`, `test_sheets_storage.py::TestInMemoryStorage`, `TestSchemaValidation`; `test_kinozal_pipeline.py::TestPipelineDeduplication`, `TestPipelineWriteBeforeNotify`; `test_events_pipeline.py::TestEventsPipelineDeduplication` | ✅ — all pipeline tests now invoke `run_*_pipeline` directly (rewritten in [#51](https://github.com/ekolvah/kinozal_scraper/pull/51)) |
-| F. Message rendering | `test_telegram_notifier.py::TestFormatField`, `TestBuildNotification`, `TestTelegramNotifierImageFallback::test_photo_400_falls_back_to_text_send`, `TestTelegramNotifierMessageLimits::test_message_over_4096_chars_is_truncated_and_sent`, `test_caption_over_1024_chars_falls_back_to_sendmessage`; `test_kinozal_pipeline.py::TestPipelineNotificationContent`; `test_events_pipeline.py::TestEventsPipelineNotificationContent`; `test_generic_pipeline.py::TestBuildNotificationRawFallback`, `TestBuildNotificationNewlineCollapse`, `TestBuildNotificationLinks` | ✅ — messages >4096 chars are truncated client-side, captions >1024 chars fall back to `sendMessage` ([#53](https://github.com/ekolvah/kinozal_scraper/issues/53)) |
+| F. Message rendering | `test_telegram_notifier.py::TestFormatField`, `TestBuildNotification`, `TestTelegramNotifierImageFallback::test_photo_400_falls_back_to_text_send`, `TestTelegramNotifierMessageLimits::test_message_over_4096_chars_is_truncated_and_sent`, `test_caption_over_1024_chars_falls_back_to_sendmessage`; `test_kinozal_pipeline.py::TestPipelineNotificationContent`; `test_events_pipeline.py::TestEventsPipelineNotificationContent`; `test_generic_pipeline.py::TestBuildNotificationRawFallback`, `TestBuildNotificationNewlineCollapse`, `TestBuildNotificationLinks`; `test_telegram_summarizer.py::TestFormatSummaryMessage` (http-vs-non-http URL, HTML-special-char escape) | ✅ — messages >4096 chars are truncated client-side, captions >1024 chars fall back to `sendMessage` ([#53](https://github.com/ekolvah/kinozal_scraper/issues/53)) |
 | G. Trailer enrichment | `test_kinozal_pipeline.py::TestEnrichWithTrailer`, `TestKinozalKnownBugs::test_youtube_quota_exhausted_pipeline_continues_with_empty_trailer` | ✅ — quota-exhausted scenario covered pipeline-level |
-| H. Pipeline orchestration | `test_json_pipeline.py::TestJsonPipelineSourceIsolation`, `TestJsonPipelineFailedNotifications`; `test_kinozal_pipeline.py::TestPipelineFailureIsolation`, `TestPipelineWriteBeforeNotify`; `test_events_pipeline.py::TestEventsPipelineEdgeCases` | ✅ — all pipeline tests rewritten to call production functions directly ([#51](https://github.com/ekolvah/kinozal_scraper/pull/51)) |
+| H. Pipeline orchestration | `test_json_pipeline.py::TestJsonPipelineSourceIsolation`, `TestJsonPipelineFailedNotifications`; `test_kinozal_pipeline.py::TestPipelineFailureIsolation`, `TestPipelineWriteBeforeNotify`; `test_events_pipeline.py::TestEventsPipelineEdgeCases`; `test_telegram_summarizer.py::TestSummarizeChannelsOrchestration` (one-channel-error isolation, empty-text/empty-summary skip) | ✅ — all pipeline tests rewritten to call production functions directly ([#51](https://github.com/ekolvah/kinozal_scraper/pull/51)); Telegram summarizer orchestration covered via Protocol doubles ([#45](https://github.com/ekolvah/kinozal_scraper/issues/45)) |
 | I. URL resolution | `test_kinozal_pipeline.py::TestKinozalUrls`, `TestBaseUrlResolution`, `TestKinozalEmptyUrlGuard::test_url_field_drift_logs_warning_but_still_notifies`; `test_generic_pipeline.py::TestBuildNotificationLinks` | ✅ — kinozal items with empty `url` after extraction emit WARNING; item still notified so the user sees the missing link and reports the drift ([#56](https://github.com/ekolvah/kinozal_scraper/issues/56)) |
 | J. Concurrent state | none | ❌ gap — no tests for rerun-after-crash or partially-written rows |
 
@@ -38,9 +38,6 @@ row promoted to ✅.
 |---|---|---|
 | `youtube.py` | No Protocol boundary, requires live YouTube API | Indirect coverage via `test_kinozal_pipeline.py::TestEnrichWithTrailer` |
 | `text_utils.py` | Small utility | Indirect coverage via `test_kinozal_pipeline.py::TestTitleYearMatches` |
-| `TelegramChannelSummarizer.py` | Legacy, excluded from linting | None |
-| `crypto.py` | Legacy, excluded from linting | None |
-| `telegram_summarizer.py` | Legacy entry point (wiring only) | None |
 | `scripts/ci_check.py` | Meta-tooling | None |
 
 ## Test patterns
@@ -52,7 +49,7 @@ row promoted to ✅.
 
 <!-- AUTOGEN:INVENTORY:START -->
 
-## Inventory (232 tests)
+## Inventory (257 tests)
 
 Auto-generated by `python scripts/gen_test_coverage.py`. Do not edit manually.
 
@@ -64,9 +61,11 @@ Auto-generated by `python scripts/gen_test_coverage.py`. Do not edit manually.
 | `test_json_pipeline.py` | `json_pipeline.py` | 27 | 12 |
 | `test_telegram_notifier.py` | `telegram_notifier.py` | 24 | 8 |
 | `test_sheets_storage.py` | `sheets_storage.py` | 22 | 4 |
+| `test_telegram_summarizer.py` | `telegram_summarizer.py` | 20 | 4 |
 | `test_gemini_enricher.py` | `gemini_enricher.py` | 18 | 6 |
 | `test_github_trending_pipeline.py` | `github_trending_pipeline.py` | 18 | 6 |
 | `test_events_pipeline.py` | `events_pipeline.py` | 16 | 4 |
+| `test_crypto.py` | `crypto.py` | 5 | 1 |
 | `test_e2e_kinozal_titles.py` | `e2e_kinozal_titles.py` | 3 | 1 |
 | `test_e2e_github_trending.py` | `e2e_github_trending.py` | 2 | 1 |
 

--- a/specs/005-telegram-summarizer-tests/spec.md
+++ b/specs/005-telegram-summarizer-tests/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: Test coverage for telegram_summarizer / TelegramChannelSummarizer / crypto
+
+**Feature Branch**: `codex-issue-45-tests-telegram-summarizer`
+
+**Created**: 2026-05-18
+
+**Status**: Draft
+
+**Parent**: #45 (PR2 of 3)
+
+**Input**: PR1 (#90, merged) refactored `TelegramChannelSummarizer` to
+expose Protocol-injected surfaces (`TelegramReader`, `Summarizer`,
+`summarize_channels`) and turned `crypto.py` into pure helpers with
+file-IO wrappers. The three modules still have no tests and are listed
+in `test-coverage.md` under "Modules without dedicated tests". This PR
+adds taxonomy-coverage tests against the new Protocol surface using the
+existing project conventions (Protocol doubles for the boundary,
+`unittest.mock.patch` only against the external `genai` client — the same
+pattern `test_gemini_enricher.py` uses).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — taxonomy bugs in the cron path get caught before merge (P1)
+
+As the engineer making changes to the daily Telegram-channel-summary
+cron, when I touch `summarize_channels`, `GeminiSummarizer`, or the
+notification-text format, I want the test suite to fail if I break:
+
+- orchestration isolation (one channel error masking the others — H),
+- Gemini quota fallback (model rotation on `ResourceExhausted` — C),
+- Telethon error swallow (one channel crashing the whole run — C),
+- crypto round-trip and key mismatch detection (security regression),
+- message rendering (`📢 Канал: …` template HTML-escape and link logic — F).
+
+**Why this priority**: Today these scenarios are uncovered. The script
+runs daily under cron with no integration tests; structural drift in
+Gemini's API or in our refactor would only surface after a failed cron
+on production.
+
+**Independent Test**: Run `pytest tests/test_telegram_summarizer.py
+tests/test_crypto.py -v`. All new tests pass without network or live
+secrets.
+
+**Acceptance Scenarios**:
+
+1. **Given** the new `summarize_channels` test with a stub reader that
+   returns `(None, "", False)` for one channel and valid data for two
+   others, **When** the function runs, **Then** the result contains
+   exactly two `ChannelSummary`s and the stub summarizer was called
+   exactly twice (skip path verified).
+2. **Given** the new `GeminiSummarizer` test with `genai.GenerativeModel`
+   patched so the first model raises `ResourceExhausted`, **When**
+   `summarize(...)` is called, **Then** the second model is tried and
+   its response is returned; the warning log mentions the first model
+   name.
+3. **Given** `encrypt_bytes(data, key)`, **When** I feed the ciphertext
+   to `decrypt_bytes(ciphertext, key)`, **Then** I get back the original
+   bytes. Decrypting with a different generated key raises
+   `cryptography.fernet.InvalidToken`.
+4. **Given** `format_summary_message(ChannelSummary)`, **When** the URL
+   starts with `http`, **Then** the rendered text wraps the channel name
+   in an `<a href=...>` tag; when it doesn't, the channel name is plain
+   HTML-escaped text.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: `tests/test_crypto.py` MUST cover:
+  - Round-trip: `decrypt_bytes(encrypt_bytes(data, key), key) == data` for
+    several payload sizes.
+  - Wrong-key path: decrypting with a different Fernet key raises
+    `cryptography.fernet.InvalidToken`.
+  - Non-determinism: two `encrypt_bytes(data, key)` calls produce
+    different ciphertexts (Fernet's random IV).
+- **FR-002**: `tests/test_telegram_summarizer.py` MUST cover:
+  - **H** orchestration — one-channel-error isolation: stub
+    `TelegramReader` returns `(None, "", False)` for one URL and valid
+    data for others; `summarize_channels` skips only the failing channel.
+  - **H** orchestration — empty-text skip: stub returns
+    `(title, "", False)`; summarizer is NOT called for that URL.
+  - **H** orchestration — empty-summary skip: stub summarizer returns
+    `""`; no `ChannelSummary` is added for that URL.
+  - **C** Gemini quota — sequential fallback on `ResourceExhausted` until
+    a model succeeds.
+  - **C** Gemini quota — all models exhausted → returns empty string,
+    error logged.
+  - **C** Non-quota exception → returns empty string immediately, error
+    logged, next models NOT tried (preserves current behaviour from
+    `TelegramChannelSummarizer.py:86-87`).
+  - **C** Telethon error swallow — `_fetch_channel_async` raising any
+    `Exception` returns `(None, "", False)` from `TelethonReader`.
+  - **F** Message rendering — `format_summary_message` with http URL →
+    `<a href=...>` label; without http URL → plain escaped.
+  - **F** Message rendering — HTML special chars in `summary` and
+    `channel` are escaped.
+- **FR-003**: A small extraction refactor is in scope for this PR: the
+  per-summary message construction currently inlined in
+  `telegram_summarizer.py` `__main__` (lines 26-30) MUST move into a
+  module-level pure function `format_summary_message(summary:
+  ChannelSummary) -> str` so it is unit-testable. `__main__` calls the
+  helper. No behaviour change.
+- **FR-004**: `test-coverage.md` MUST be updated:
+  - Remove `TelegramChannelSummarizer.py`, `crypto.py`,
+    `telegram_summarizer.py` from "Modules without dedicated tests".
+  - Append references to the new tests in the C, F, H category rows.
+- **FR-005**: NO removal of ruff/mypy/CI exclusions in this PR (PR3's
+  job). The new test files MUST pass ruff + mypy under the existing
+  config without temporary `# type: ignore` comments.
+
+### Success Criteria
+
+- **SC-001**: After this PR, the three previously-untested production
+  files have at least one test each that calls the production function
+  directly with a Protocol double (no in-test reimplementation of
+  business logic — `testing.md` anti-pattern rule).
+- **SC-002**: `python scripts/ci_check.py` green; new test count +N
+  visible in the auto-generated inventory.
+
+## Assumptions
+
+- `unittest.mock.patch` against `TelegramChannelSummarizer.genai.GenerativeModel`
+  is acceptable — it's the same external-boundary pattern
+  `test_gemini_enricher.py` uses for `GeminiEnricher._generate`.
+- The existing `summarize_channels` signature does not change. The
+  `format_summary_message` extraction is the only structural change in
+  this PR.
+- `TelethonReader` does NOT get tested against a real Telegram client —
+  only the swallow-on-exception path is verified by patching
+  `_fetch_channel_async` to raise.
+
+## Out of scope (deferred to PR3)
+
+- Removing the legacy-exclusions in `pyproject.toml`,
+  `scripts/ci_check.py`, `.github/workflows/ci.yml`, `CLAUDE.md`.
+- Promoting `telegram_summarizer.py` from "Legacy entry point (wiring
+  only)" to a fully-gated module — that follows from PR3.
+- Migrating away from `google.generativeai`.

--- a/specs/005-telegram-summarizer-tests/tasks.md
+++ b/specs/005-telegram-summarizer-tests/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Test coverage for telegram_summarizer / TelegramChannelSummarizer / crypto (PR2 of 3)
+
+**Input**: [spec.md](./spec.md)
+
+**Tests are the deliverable** — Constitution Principle I. The two new
+files + the small `format_summary_message` extraction together satisfy
+FR-001 through FR-004.
+
+## Phase 1: Refactor for testability
+
+- [ ] **T1** `telegram_summarizer.py` — extract the per-summary message
+      construction from the `__main__` block into a module-level
+      `format_summary_message(summary: ChannelSummary) -> str`. `__main__`
+      calls the helper. Output byte-identical to pre-PR. Type
+      annotations.
+
+## Phase 2: New tests
+
+- [ ] **T2** `tests/test_crypto.py`:
+  - `TestCryptoRoundTrip::test_encrypt_decrypt_round_trip` — random key,
+    multiple payload sizes.
+  - `TestCryptoRoundTrip::test_decrypt_with_wrong_key_raises` —
+    `InvalidToken`.
+  - `TestCryptoRoundTrip::test_encrypt_is_non_deterministic` — two
+    encrypts produce different ciphertexts.
+- [ ] **T3** `tests/test_telegram_summarizer.py`:
+  - `TestSummarizeChannelsOrchestration` (H):
+    - `test_one_channel_error_does_not_block_others`
+    - `test_empty_text_skips_summarizer`
+    - `test_empty_summary_not_added_to_results`
+  - `TestGeminiSummarizerQuota` (C):
+    - `test_first_model_quota_falls_back_to_next` (patches
+      `genai.GenerativeModel`)
+    - `test_all_models_exhausted_returns_empty`
+    - `test_non_quota_exception_returns_empty_without_fallback`
+  - `TestTelethonReaderErrorSwallow` (C):
+    - `test_fetch_channel_swallows_exception_returns_error_tuple` —
+      patches `TelethonReader._fetch_channel_async` to raise.
+  - `TestFormatSummaryMessage` (F):
+    - `test_http_url_wraps_channel_in_anchor`
+    - `test_non_http_url_renders_plain_text`
+    - `test_html_special_chars_escaped`
+
+## Phase 3: Docs + polish
+
+- [ ] **T4** `docs/architecture/test-coverage.md`:
+  - Remove the 3 rows in "Modules without dedicated tests" for
+    `TelegramChannelSummarizer.py`, `crypto.py`, `telegram_summarizer.py`.
+  - Append the new test references to category rows C, F, H.
+- [ ] **T5** `python scripts/ci_check.py` — green.
+- [ ] **T6** Commit, push, `gh pr create` referencing #45 (PR2/3). No
+      self-merge.
+
+## Out of scope (PR3)
+
+- Removing the legacy ruff/mypy/CI exclusions from `pyproject.toml`,
+  `scripts/ci_check.py`, `.github/workflows/ci.yml`, `CLAUDE.md`.
+- Live-Telethon integration test (no credentials in CI).

--- a/telegram_summarizer.py
+++ b/telegram_summarizer.py
@@ -4,7 +4,23 @@ import html as _html
 import logging
 import os
 
+from TelegramChannelSummarizer import ChannelSummary
+
 logger = logging.getLogger(__name__)
+
+
+def format_summary_message(summary: ChannelSummary) -> str:
+    """Render one `ChannelSummary` for Telegram. Output is HTML-formatted:
+    if `summary.url` is an `http[s]://` URL, the channel name is wrapped
+    in an anchor tag; otherwise the channel name is plain HTML-escaped.
+    The body line is always HTML-escaped to keep Telegram's parser
+    happy regardless of what Gemini returned.
+    """
+    if summary.url and summary.url.startswith("http"):
+        channel_label = f'<a href="{summary.url}">{_html.escape(summary.channel)}</a>'
+    else:
+        channel_label = _html.escape(summary.channel)
+    return f"📢 Канал: {channel_label}\n\n{_html.escape(summary.summary)}"
 
 
 if __name__ == "__main__":
@@ -56,14 +72,7 @@ if __name__ == "__main__":
     summaries = summarize_channels(reader, summarizer, channel_urls)
     if summaries:
         notifier.send_text("🔍 Обзор сообщений в каналах за последние сутки:")
-
         for item in summaries:
-            channel_url = item.url
-            if channel_url and isinstance(channel_url, str) and channel_url.startswith("http"):
-                channel_label = f'<a href="{channel_url}">{_html.escape(item.channel)}</a>'
-            else:
-                channel_label = _html.escape(item.channel)
-            message = f"📢 Канал: {channel_label}\n\n{_html.escape(item.summary)}"
-            notifier.send_text(message)
+            notifier.send_text(format_summary_message(item))
     else:
         notifier.send_text("За последние сутки в отслеживаемых каналах не было новых сообщений.")

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import unittest
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from crypto import decrypt_bytes, encrypt_bytes
+
+
+class TestCryptoRoundTrip(unittest.TestCase):
+    def test_encrypt_decrypt_round_trip_small_payload(self) -> None:
+        key = Fernet.generate_key()
+        data = b"hello world"
+        self.assertEqual(decrypt_bytes(encrypt_bytes(data, key), key), data)
+
+    def test_encrypt_decrypt_round_trip_empty_payload(self) -> None:
+        key = Fernet.generate_key()
+        self.assertEqual(decrypt_bytes(encrypt_bytes(b"", key), key), b"")
+
+    def test_encrypt_decrypt_round_trip_binary_payload(self) -> None:
+        # Mimic an anon.session blob — arbitrary binary, including null bytes.
+        key = Fernet.generate_key()
+        data = bytes(range(256)) * 16
+        self.assertEqual(decrypt_bytes(encrypt_bytes(data, key), key), data)
+
+    def test_decrypt_with_wrong_key_raises(self) -> None:
+        key_a = Fernet.generate_key()
+        key_b = Fernet.generate_key()
+        ciphertext = encrypt_bytes(b"top secret", key_a)
+        with self.assertRaises(InvalidToken):
+            decrypt_bytes(ciphertext, key_b)
+
+    def test_encrypt_is_non_deterministic(self) -> None:
+        # Fernet uses a random IV per call — same input, different ciphertext.
+        key = Fernet.generate_key()
+        a = encrypt_bytes(b"same data", key)
+        b = encrypt_bytes(b"same data", key)
+        self.assertNotEqual(a, b)
+        # But both decrypt back to the same plaintext.
+        self.assertEqual(decrypt_bytes(a, key), decrypt_bytes(b, key))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram_summarizer.py
+++ b/tests/test_telegram_summarizer.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import unittest
+import unittest.mock
+from typing import Any
+
+import google.api_core.exceptions
+
+from telegram_summarizer import format_summary_message
+from TelegramChannelSummarizer import (
+    ChannelMessages,
+    ChannelSummary,
+    GeminiSummarizer,
+    Summarizer,
+    TelegramReader,
+    TelethonReader,
+    summarize_channels,
+)
+
+# ── Test doubles for summarize_channels (Protocol surface) ───────────────────
+
+
+class _FakeReader:
+    def __init__(self, mapping: dict[str, ChannelMessages]) -> None:
+        self._mapping = mapping
+        self.calls: list[str] = []
+
+    def fetch_channel(self, channel_url: str) -> ChannelMessages:
+        self.calls.append(channel_url)
+        return self._mapping[channel_url]
+
+
+class _FakeSummarizer:
+    def __init__(self, returns: str = "summary-text") -> None:
+        self._returns = returns
+        self.calls: list[tuple[str, bool]] = []
+
+    def summarize(self, text: str, is_broadcast: bool) -> str:
+        self.calls.append((text, is_broadcast))
+        return self._returns
+
+
+# ── H. Pipeline orchestration ────────────────────────────────────────────────
+
+
+class TestSummarizeChannelsOrchestration(unittest.TestCase):
+    def test_implements_protocols(self) -> None:
+        # Anchor that the fakes are actually structural-typed against the
+        # Protocols — if anyone tightens the Protocol surface this catches it.
+        self.assertIsInstance(_FakeReader({}), TelegramReader)
+        self.assertIsInstance(_FakeSummarizer(), Summarizer)
+
+    def test_one_channel_error_does_not_block_others(self) -> None:
+        reader = _FakeReader(
+            {
+                "https://t.me/good_a": ("Канал A", "msg a", True),
+                "https://t.me/broken": (None, "", False),  # reader-error tuple
+                "https://t.me/good_b": ("Канал B", "msg b", False),
+            }
+        )
+        summarizer = _FakeSummarizer(returns="ok")
+        results = summarize_channels(
+            reader,
+            summarizer,
+            ["https://t.me/good_a", "https://t.me/broken", "https://t.me/good_b"],
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual([r.channel for r in results], ["Канал A", "Канал B"])
+        # Summarizer was NOT called for the broken channel.
+        self.assertEqual(len(summarizer.calls), 2)
+
+    def test_empty_text_skips_summarizer(self) -> None:
+        reader = _FakeReader({"u": ("Канал X", "", False)})
+        summarizer = _FakeSummarizer()
+        results = summarize_channels(reader, summarizer, ["u"])
+
+        self.assertEqual(results, [])
+        self.assertEqual(summarizer.calls, [])
+
+    def test_empty_summary_not_added_to_results(self) -> None:
+        reader = _FakeReader({"u": ("Канал X", "real text", False)})
+        summarizer = _FakeSummarizer(returns="")  # model produced nothing
+        results = summarize_channels(reader, summarizer, ["u"])
+
+        self.assertEqual(results, [])
+        # Summarizer WAS called, but result was dropped because empty.
+        self.assertEqual(len(summarizer.calls), 1)
+
+    def test_no_channel_title_falls_back_to_url_as_display_name(self) -> None:
+        reader = _FakeReader({"u": (None, "text", False)})
+        # title=None but text non-empty is an unusual but legal shape — display
+        # name should fall back to the url string.
+        summarizer = _FakeSummarizer(returns="sum")
+        results = summarize_channels(reader, summarizer, ["u"])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].channel, "u")
+
+
+# ── C. Auth & quota — GeminiSummarizer ──────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, text: str, has_candidates: bool = True) -> None:
+        self.text = text
+        self.candidates = [object()] if has_candidates else []
+
+
+class TestGeminiSummarizerQuota(unittest.TestCase):
+    def test_empty_text_short_circuits(self) -> None:
+        summ = GeminiSummarizer(models=["m1"], broadcast_prompt="b", chat_prompt="c")
+        with unittest.mock.patch("TelegramChannelSummarizer.genai.GenerativeModel") as mock_model:
+            result = summ.summarize("", False)
+        self.assertEqual(result, "")
+        mock_model.assert_not_called()
+
+    def test_first_model_quota_falls_back_to_next(self) -> None:
+        summ = GeminiSummarizer(models=["m-a", "m-b"], broadcast_prompt="b", chat_prompt="c")
+
+        # First model raises ResourceExhausted, second returns a response.
+        def factory(name: str) -> Any:
+            instance = unittest.mock.MagicMock()
+            if name == "m-a":
+                instance.generate_content.side_effect = (
+                    google.api_core.exceptions.ResourceExhausted("quota")
+                )
+            else:
+                instance.generate_content.return_value = _FakeResponse("from-b")
+            return instance
+
+        with unittest.mock.patch(
+            "TelegramChannelSummarizer.genai.GenerativeModel", side_effect=factory
+        ):
+            result = summ.summarize("text", is_broadcast=False)
+        self.assertEqual(result, "from-b")
+
+    def test_all_models_exhausted_returns_empty(self) -> None:
+        summ = GeminiSummarizer(models=["m1", "m2"], broadcast_prompt="b", chat_prompt="c")
+        with unittest.mock.patch("TelegramChannelSummarizer.genai.GenerativeModel") as mock_model:
+            mock_model.return_value.generate_content.side_effect = (
+                google.api_core.exceptions.ResourceExhausted("quota")
+            )
+            result = summ.summarize("text", is_broadcast=True)
+        self.assertEqual(result, "")
+        # Both models were tried.
+        self.assertEqual(mock_model.call_count, 2)
+
+    def test_non_quota_exception_returns_empty_without_fallback(self) -> None:
+        """Behaviour pinned from TelegramChannelSummarizer.py:86-87 — any
+        non-`ResourceExhausted` exception aborts the loop. We don't try the
+        next model on a generic failure (different from `ResourceExhausted`
+        which is per-model)."""
+        summ = GeminiSummarizer(models=["m1", "m2"], broadcast_prompt="b", chat_prompt="c")
+        with unittest.mock.patch("TelegramChannelSummarizer.genai.GenerativeModel") as mock_model:
+            mock_model.return_value.generate_content.side_effect = RuntimeError("net down")
+            result = summ.summarize("text", False)
+        self.assertEqual(result, "")
+        # Only the first model was tried.
+        self.assertEqual(mock_model.call_count, 1)
+
+    def test_no_candidates_returns_empty(self) -> None:
+        summ = GeminiSummarizer(models=["m1"], broadcast_prompt="b", chat_prompt="c")
+        with unittest.mock.patch("TelegramChannelSummarizer.genai.GenerativeModel") as mock_model:
+            mock_model.return_value.generate_content.return_value = _FakeResponse(
+                "", has_candidates=False
+            )
+            result = summ.summarize("text", False)
+        self.assertEqual(result, "")
+
+    def test_broadcast_uses_broadcast_prompt(self) -> None:
+        summ = GeminiSummarizer(models=["m1"], broadcast_prompt="BROADCAST", chat_prompt="CHAT")
+        with unittest.mock.patch("TelegramChannelSummarizer.genai.GenerativeModel") as mock_model:
+            mock_model.return_value.generate_content.return_value = _FakeResponse("ok")
+            summ.summarize("payload", is_broadcast=True)
+        called_request = mock_model.return_value.generate_content.call_args.args[0]
+        self.assertIn("BROADCAST", called_request)
+        self.assertNotIn("CHAT", called_request)
+
+    def test_chat_uses_chat_prompt(self) -> None:
+        summ = GeminiSummarizer(models=["m1"], broadcast_prompt="BROADCAST", chat_prompt="CHAT")
+        with unittest.mock.patch("TelegramChannelSummarizer.genai.GenerativeModel") as mock_model:
+            mock_model.return_value.generate_content.return_value = _FakeResponse("ok")
+            summ.summarize("payload", is_broadcast=False)
+        called_request = mock_model.return_value.generate_content.call_args.args[0]
+        self.assertIn("CHAT", called_request)
+        self.assertNotIn("BROADCAST", called_request)
+
+
+# ── C. Auth & quota — TelethonReader error swallow ──────────────────────────
+
+
+class TestTelethonReaderErrorSwallow(unittest.TestCase):
+    def test_fetch_channel_swallows_exception_returns_error_tuple(self) -> None:
+        """If anything goes wrong inside `_fetch_channel_async`'s
+        try-block (session expired, network down, channel not found), the
+        reader MUST return `(None, "", False)` so `summarize_channels`
+        keeps processing the rest of the channels. Losing this swallow
+        would let one bad channel kill the whole cron.
+
+        Caveat (preserved from pre-refactor): `TelegramClient(...)` and
+        `StringSession(...)` are constructed OUTSIDE the try-block, so a
+        malformed session-string raises before the swallow fires. That's
+        intentional (PR1 was byte-identical). Tests of the swallow path
+        use `session=None` (the `'anon'` filename branch) and inject a
+        mock client whose `start()` raises.
+        """
+        reader = TelethonReader(api_id="x", api_hash="y", session=None, phone="p")
+        mock_client = unittest.mock.MagicMock()
+        mock_client.start = unittest.mock.AsyncMock(side_effect=RuntimeError("session expired"))
+        mock_client.disconnect = unittest.mock.AsyncMock()
+
+        with unittest.mock.patch(
+            "TelegramChannelSummarizer.TelegramClient",
+            return_value=mock_client,
+        ):
+            result = reader.fetch_channel("https://t.me/whatever")
+
+        self.assertEqual(result, (None, "", False))
+        mock_client.disconnect.assert_awaited_once()
+
+
+# ── F. Message rendering — format_summary_message ───────────────────────────
+
+
+class TestFormatSummaryMessage(unittest.TestCase):
+    def test_http_url_wraps_channel_in_anchor(self) -> None:
+        s = ChannelSummary(channel="Канал X", url="https://t.me/x", summary="темы дня")
+        text = format_summary_message(s)
+        self.assertIn('<a href="https://t.me/x">', text)
+        self.assertIn("Канал X</a>", text)
+        self.assertIn("📢 Канал:", text)
+        self.assertIn("темы дня", text)
+
+    def test_https_url_also_anchored(self) -> None:
+        s = ChannelSummary(channel="Z", url="http://example.com/c", summary="sum")
+        self.assertIn('<a href="http://example.com/c">', format_summary_message(s))
+
+    def test_non_http_url_renders_plain_text(self) -> None:
+        # When the input was something like "-1001537004903" — no anchor.
+        s = ChannelSummary(channel="Канал Z", url="-1001537004903", summary="sum")
+        text = format_summary_message(s)
+        self.assertNotIn("<a href", text)
+        self.assertIn("Канал Z", text)
+
+    def test_empty_url_renders_plain_text(self) -> None:
+        s = ChannelSummary(channel="C", url="", summary="sum")
+        text = format_summary_message(s)
+        self.assertNotIn("<a href", text)
+
+    def test_html_special_chars_in_summary_escaped(self) -> None:
+        s = ChannelSummary(channel="C", url="", summary="<script>alert(1)</script>")
+        text = format_summary_message(s)
+        # Raw <script> would let Telegram render it as HTML — escape it.
+        self.assertNotIn("<script>", text)
+        self.assertIn("&lt;script&gt;", text)
+
+    def test_html_special_chars_in_channel_name_escaped(self) -> None:
+        s = ChannelSummary(channel="A & B <3", url="", summary="sum")
+        text = format_summary_message(s)
+        self.assertNotIn("A & B <3", text)
+        self.assertIn("A &amp; B &lt;3", text)
+
+    def test_html_chars_escaped_even_with_http_url(self) -> None:
+        # URL goes inside href untouched (it's a URL — http-only path);
+        # channel name still escaped.
+        s = ChannelSummary(channel="A & B", url="https://t.me/c", summary="t")
+        text = format_summary_message(s)
+        self.assertIn("A &amp; B</a>", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR2 of three from #45. Adds dedicated tests for the three previously-untested production files. The Protocol seam from PR1 (#90) keeps this clean — no production code changes apart from one small extraction.

- **`tests/test_crypto.py`** (5 tests, pure unit): `encrypt_bytes`/`decrypt_bytes` round-trip across payload sizes, wrong-key `InvalidToken`, non-deterministic ciphertext.
- **`tests/test_telegram_summarizer.py`** (20 tests, taxonomy H + C + F):
  - **H. Orchestration** — `summarize_channels` with Protocol doubles: one-channel-error isolation, empty-text skip, empty-summary skip, missing-title fallback.
  - **C. Quota** — `GeminiSummarizer.summarize` with `unittest.mock.patch` against `TelegramChannelSummarizer.genai.GenerativeModel` (same pattern `test_gemini_enricher.py` uses): first-model-quota fallback, all-exhausted-returns-empty, non-quota-exception-aborts, no-candidates-returns-empty, broadcast/chat prompt selection.
  - **C. Telethon** — `TelethonReader.fetch_channel` swallows exceptions to `(None, "", False)` (mock `TelegramClient.start` raises).
  - **F. Rendering** — `format_summary_message` http-URL anchored, non-http plain, HTML special chars escaped.
- **`telegram_summarizer.py`** — extracts the per-summary message rendering from `__main__` into module-level `format_summary_message(ChannelSummary)`. Output byte-identical.
- **`docs/architecture/test-coverage.md`** — removes the three legacy rows from "Modules without dedicated tests"; appends new test references to C/F/H rows.

## Deferred to PR3

- Lifting ruff/mypy/CI exclusions in `pyproject.toml`, `scripts/ci_check.py`, `.github/workflows/ci.yml`, `CLAUDE.md`. PR3 will make the quality-gate enforcement structural now that tests exist.

## Test plan

- [x] `python scripts/ci_check.py` — green, 257 tests (+25).
- [ ] Operator: optional `workflow_dispatch` smoke after merge — PR2 is test-only, so a fresh smoke isn't strictly required, but it's cheap insurance before PR3 turns the gates on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)