### PR TITLE
chore: lift ruff/mypy exclusions for Telegram summarizer files (closes #45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,7 @@ jobs:
         run: |
           mapfile -t modules < <(find . -name "*.py" \
             ! -path "./.venv/*" ! -path "./.git/*" ! -path "./__pycache__/*" \
-            ! -path "./.claude/*" \
-            ! -name "telegram_summarizer.py" \
-            ! -name "TelegramChannelSummarizer.py" \
-            ! -name "crypto.py")
+            ! -path "./.claude/*")
           if [ "${#modules[@]}" -eq 0 ]; then
             echo "No modules to type-check; skipping."
           else

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -7,8 +7,6 @@ python scripts/ci_check.py
 ```
 
 Runs: ruff format check → ruff lint → pytest → mypy.
-Legacy files (`telegram_summarizer.py`, `TelegramChannelSummarizer.py`, `crypto.py`)
-are excluded from ruff and mypy.
 
 Pre-push hook: `.githooks/pre-push` runs `ci_check.py` automatically.
 Activate: `git config core.hooksPath .githooks`
@@ -19,7 +17,9 @@ Triggers: PR and push to `main` / `codex-*` branches.
 
 Steps: checkout → Python 3.12 → install deps → ruff format → ruff lint → pytest → mypy → pip-audit.
 
-mypy excludes the same legacy files as `ci_check.py`, plus `.claude` directory.
+mypy excludes only `scraper.py` (legacy WebDriver script with its own
+issue trail) and the `.claude` directory. All other Python files are
+type-checked.
 
 ## Claude review workflow (`claude-review.yml`)
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -9,9 +9,10 @@
 | `kinozal_pipeline.py` | Kinozal movies | HTML scraping | daily 04:00 UTC |
 | `telegram_summarizer.py` | Telegram channels | Gemini summarization | daily 04:00 UTC, `if: always()` |
 
-All pipelines except `telegram_summarizer` follow the generic pipeline pattern.
-`telegram_summarizer` is legacy code (excluded from linting) that uses
-`TelegramChannelSummarizer` + Gemini directly.
+All pipelines except `telegram_summarizer` follow the generic pipeline
+pattern. `telegram_summarizer` uses `TelegramChannelSummarizer` (Telethon
+reader + Gemini summarizer behind Protocols) and the shared `TelegramNotifier`
+— see [Telethon-direct modules](#telethon-direct-modules) below.
 
 ## Protocols
 
@@ -44,8 +45,16 @@ Details in [pipeline.md](pipeline.md).
 - `pipeline_config.py` — loads config, expands macros (`{{TODAY}}`, `{{GITHUB_TOP_LIMIT}}`), validates
 - Env vars override runtime behavior — full list in [ci.md](ci.md)
 
-## Legacy modules
+## Telethon-direct modules
 
-`TelegramChannelSummarizer.py`, `crypto.py`, `telegram_summarizer.py` are excluded
-from ruff and mypy (see CLAUDE.md). They use Telethon + Gemini directly, not the
-generic pipeline. Model rotation strategy shared with generic pipeline — see [gemini.md](gemini.md).
+`TelegramChannelSummarizer.py`, `crypto.py`, and `telegram_summarizer.py`
+use Telethon + Gemini directly rather than going through the generic
+pipeline (sources.json → declarative extraction → Storage → Notifier).
+The reason is the domain: they read live Telegram channels, decrypt a
+Telethon session, and summarize free-form chat — none of which fits the
+"fetch → extract → dedupe → notify" shape the other pipelines share.
+
+They are nevertheless covered by the same quality gates: ruff format,
+ruff lint, mypy, and dedicated tests (`test_telegram_summarizer.py`,
+`test_crypto.py`). Model rotation is the same strategy as the generic
+pipelines — see [gemini.md](gemini.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,6 @@ extend-exclude = [
     ".venv",
     "__pycache__",
     "pytest-cache-files-*",
-    "TelegramChannelSummarizer.py",
-    "crypto.py",
-    "telegram_summarizer.py",
 ]
 
 [tool.ruff.lint]
@@ -49,6 +46,4 @@ check_untyped_defs = true
 ignore_missing_imports = true
 exclude = [
     "^scraper\\.py$",
-    "^TelegramChannelSummarizer\\.py$",
-    "^crypto\\.py$",
 ]

--- a/scripts/ci_check.py
+++ b/scripts/ci_check.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-_LEGACY = {"telegram_summarizer.py", "TelegramChannelSummarizer.py", "crypto.py"}
 _EXCLUDE_DIRS = {".venv", ".git", "__pycache__", ".audit-tmp", ".claude"}
 
 
@@ -23,7 +22,6 @@ def _find_modules() -> list[str]:
         for p in Path(".").rglob("*.py")
         if not (_EXCLUDE_DIRS & set(p.parts))
         and not any(part.startswith("pytest-cache-files-") for part in p.parts)
-        and p.name not in _LEGACY
     ]
 
 

--- a/specs/006-lift-legacy-exclusions/spec.md
+++ b/specs/006-lift-legacy-exclusions/spec.md
@@ -1,0 +1,110 @@
+# Feature Specification: Lift legacy ruff/mypy exclusions for the Telegram summarizer files
+
+**Feature Branch**: `codex-issue-45-lift-exclusions`
+
+**Created**: 2026-05-18
+
+**Status**: Draft
+
+**Parent**: #45 (PR3 of 3 — closes the issue)
+
+**Input**: PR1 (#90) refactored the three legacy files to Protocol-injected,
+mypy-clean shape. PR2 (#91) added taxonomy-coverage tests. The exclusions
+across `pyproject.toml`, `scripts/ci_check.py`, and `.github/workflows/ci.yml`
+remained in place so behaviour changes could be reverted independently. With
+both PRs merged, the gate flip is structural — and the docs that still
+mention "excluded from ruff and mypy" become stale the moment this PR lands.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — quality gates uniformly enforced (P1)
+
+As the engineer making changes to `telegram_summarizer.py`,
+`TelegramChannelSummarizer.py`, or `crypto.py`, when I run
+`python scripts/ci_check.py` (or push, triggering CI), I want ruff and
+mypy to be applied to those files exactly like every other Python file
+in the repo. No silent skip.
+
+**Why this priority**: The whole point of #45 was to remove the
+"production code with no quality gate" anomaly. PR1 + PR2 set up the
+foundation; this PR completes it.
+
+**Independent Test**: `python scripts/ci_check.py` reports
+`27 source files` (or whatever the post-lift count is — exact number
+verified at commit time) for the mypy stage, where today it reports 27
+*excluding* the three legacy files. Manually introduce a type error in
+`TelegramChannelSummarizer.py` → ci_check fails. Revert → green.
+
+**Acceptance Scenarios**:
+
+1. **Given** `pyproject.toml` with the three legacy entries removed from
+   both ruff `extend-exclude` and mypy `exclude`, **When** I run
+   `python -m ruff check .` and `python -m mypy <all .py>`, **Then**
+   both pass against the merged content from PR1 + PR2.
+2. **Given** `scripts/ci_check.py` with the `_LEGACY` set removed,
+   **When** the script enumerates modules for type-checking, **Then**
+   the three previously-excluded files are included in the list and
+   pass.
+3. **Given** the CI workflow `.github/workflows/ci.yml` with the three
+   `! -name "..."` filters removed from the `find` invocation,
+   **When** CI runs on this PR, **Then** the `Type check` step
+   succeeds with the legacy files included.
+4. **Given** the architecture docs (`ci.md`, `runtime.md`) updated to
+   remove the "legacy files excluded" notes, **When** a developer reads
+   the docs after this PR, **Then** they get a consistent story —
+   nothing claims the files are excluded, because they no longer are.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: `pyproject.toml` `[tool.ruff].extend-exclude` MUST NOT
+  reference `TelegramChannelSummarizer.py`, `crypto.py`, or
+  `telegram_summarizer.py`. All other entries unchanged.
+- **FR-002**: `pyproject.toml` `[tool.mypy].exclude` MUST NOT reference
+  `^TelegramChannelSummarizer\.py$` or `^crypto\.py$`. The
+  `^scraper\.py$` exclusion stays.
+- **FR-003**: `scripts/ci_check.py` `_LEGACY` set MUST be removed
+  entirely. `_find_modules()` filtering no longer skips by filename.
+- **FR-004**: `.github/workflows/ci.yml` `Type check` step's `find`
+  command MUST drop the three `! -name "..."` filters. Everything else
+  unchanged.
+- **FR-005**: `docs/architecture/ci.md` lines that say _"Legacy files
+  (`telegram_summarizer.py`, `TelegramChannelSummarizer.py`,
+  `crypto.py`) are excluded from ruff and mypy"_ MUST be deleted. The
+  `mypy excludes the same legacy files as ci_check.py, plus .claude
+  directory` line MUST be rewritten to reflect the new state
+  (only `.claude/` and `scraper.py`).
+- **FR-006**: `docs/architecture/runtime.md` MUST drop the "legacy code
+  (excluded from linting)" claim about `telegram_summarizer.py` and
+  the "Legacy modules" section's "excluded from ruff and mypy"
+  sentence. The structural note that these modules use Telethon +
+  Gemini directly (not the generic pipeline) MAY stay — that
+  distinction is still true and useful.
+- **FR-007**: `python scripts/ci_check.py` MUST be green after the
+  edits, with the three files now included in the mypy module list.
+
+### Success Criteria
+
+- **SC-001**: After this PR, `git grep -i "excluded from ruff\|excluded
+  from linting\|_LEGACY\|TelegramChannelSummarizer.*exclude"` over the
+  repo returns no matches in source/config (specs and old commit
+  messages are fine).
+- **SC-002**: Closes #45 — the issue's Definition of Done is fully
+  satisfied: ruff clean without exclusions, mypy clean without
+  exclusions, tests exist, docs match.
+
+## Assumptions
+
+- The local-only verification done in PR1 (mypy --strict + ruff clean
+  on the three files against project config) is still valid post-PR2.
+  This PR re-runs ci_check end-to-end to confirm.
+- `scraper.py` exclusion is **not** in scope. That file pre-dates the
+  cleanup, has its own issue trail, and #45's text focuses on the
+  three Telegram-summarizer files only.
+
+## Out of scope
+
+- Migrating from `google.generativeai` to `google.genai` (separate
+  issue suggested by the `FutureWarning` we see in tests).
+- Reworking the cron workflow that runs these files.
+- Adding more tests (PR2's coverage is judged sufficient for closing
+  #45; further taxonomy gaps go in new issues).

--- a/specs/006-lift-legacy-exclusions/tasks.md
+++ b/specs/006-lift-legacy-exclusions/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: Lift legacy ruff/mypy exclusions (PR3 of 3 — closes #45)
+
+**Input**: [spec.md](./spec.md)
+
+The structural work is done; this PR flips the gates and updates the
+docs that referenced "legacy excluded files". One commit.
+
+## Phase 1: Config edits
+
+- [ ] **T1** `pyproject.toml`:
+  - `[tool.ruff].extend-exclude` — drop `TelegramChannelSummarizer.py`,
+    `crypto.py`, `telegram_summarizer.py`.
+  - `[tool.mypy].exclude` — drop `^TelegramChannelSummarizer\.py$` and
+    `^crypto\.py$`. Keep `^scraper\.py$`.
+- [ ] **T2** `scripts/ci_check.py` — remove the `_LEGACY` constant and
+      the `p.name not in _LEGACY` filter in `_find_modules()`.
+- [ ] **T3** `.github/workflows/ci.yml` — in the `Type check` step's
+      `find` command, drop the three `! -name "..."` filters.
+
+## Phase 2: Doc sync
+
+- [ ] **T4** `docs/architecture/ci.md`:
+  - Remove the "Legacy files … are excluded from ruff and mypy"
+    sentence under "Local pre-commit".
+  - Rewrite "mypy excludes the same legacy files as `ci_check.py`,
+    plus `.claude` directory" to reference only `scraper.py` +
+    `.claude/`.
+- [ ] **T5** `docs/architecture/runtime.md`:
+  - Drop the "legacy code (excluded from linting)" parenthetical for
+    `telegram_summarizer`.
+  - Rewrite the "Legacy modules" section to a "Telethon-direct
+    modules" note that explains the architectural distinction without
+    claiming exclusion.
+
+## Phase 3: Verify
+
+- [ ] **T6** `python scripts/ci_check.py` — green; verify the mypy
+      stage now reports the three files in its module count.
+- [ ] **T7** `git grep -i` over the repo for residual mentions of the
+      old exclusion state; clean up any I missed.
+- [ ] **T8** Commit, push, `gh pr create` closing #45. No self-merge.
+
+## Out of scope
+
+- `scraper.py` exclusion (separate, predates this issue).
+- Migrating away from `google.generativeai` (own issue).


### PR DESCRIPTION
## Summary

PR3 of three from #45 — closes the issue. The structural work was done in PR1 (#90, Protocol refactor) and PR2 (#91, taxonomy tests). With both merged the gate flip is structural.

- **`pyproject.toml`** — drop the three legacy files from both `[tool.ruff].extend-exclude` and `[tool.mypy].exclude`. `scraper.py` exclusion stays (its own issue trail, predates this cleanup).
- **`scripts/ci_check.py`** — remove the `_LEGACY` constant and its filter in `_find_modules()`.
- **`.github/workflows/ci.yml`** — drop the three `! -name "..."` filters from the `Type check` step's `find` command.
- **`docs/architecture/ci.md`** — remove the "Legacy files … are excluded from ruff and mypy" note; rewrite the mypy-exclude summary to mention only `scraper.py` + `.claude/`.
- **`docs/architecture/runtime.md`** — replace the "Legacy modules" section with "Telethon-direct modules" that explains the architectural distinction (these modules don't fit the declarative `sources.json → extract → notify` shape) without claiming they're excluded from quality gates, which is now false.

## Result

`python scripts/ci_check.py` reports **30 source files** at the mypy stage (was 27 — +3 newly included). 257 tests still pass. `git grep` over the repo for residual mentions of the old exclusion state returns no matches outside `specs/`.

Closes #45.

## Test plan

- [x] `python scripts/ci_check.py` — green.
- [x] `git grep -i "_LEGACY|excluded from ruff|excluded from linting|legacy files"` — no matches in src/config/docs.
- [ ] Operator: optional `workflow_dispatch` smoke after merge to confirm the daily cron path is unaffected (PR3 doesn't touch the runtime — purely a CI-config + docs PR — but it's cheap reassurance before relying on the gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)