### PR TITLE
feat: clickable repo name in GitHub notifications (closes #98)

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -36,7 +36,7 @@
         },
         "on_error": ""
       },
-      "message_template": "<b>{title}</b>\n{summary_ru}\n⭐ {metric} | {language}\n{url}"
+      "message_template": "<b>{title_link}</b>\n{summary_ru}\n⭐ {metric} | {language}"
     },
     {
       "id": "github_trending",
@@ -64,7 +64,7 @@
         },
         "on_error": ""
       },
-      "message_template": "<b>{title}</b>\n{summary_ru}\n⭐ {metric} (+{stars_today} today)\n{url}"
+      "message_template": "<b>{title_link}</b>\n{summary_ru}\n⭐ {metric} (+{stars_today} today)"
     },
     {
       "id": "steam_charts_mostplayed",


### PR DESCRIPTION
## Summary

- В `github_trending` и `github_new_popular` `message_template` заменён `<b>{title}</b>…\n{url}` на `<b>{title_link}</b>…` — название репозитория становится кликабельной ссылкой, а отдельная строка с голым URL уходит.
- Без правок Python: плейсхолдер `{title_link}` уже реализован в `generic_pipeline.build_notification` (`generic_pipeline.py:233-263`) и протестирован (`tests/test_generic_pipeline.py:243-264`). Для `github_trending` относительный `/owner/repo` склеивается с `base_url: https://github.com` в `_resolve_url`, для `github_new_popular` GitHub API сразу отдаёт абсолютный `html_url`.
- Closes #98.

## До/после

```
До:                                        После:
freestylefly/awesome-gpt-image-2           freestylefly/awesome-gpt-image-2   ← <a href="…">…</a>
Для кого: …                                Для кого: …
Зачем: …                                   Зачем: …
⭐️ 5617 | JavaScript                       ⭐️ 5617 | JavaScript
https://github.com/freestylefly/awesome-gpt-image-2
```

## Test plan

- [x] `python -m unittest tests.test_pipeline_config tests.test_generic_pipeline tests.test_github_trending_pipeline tests.test_json_pipeline` — 100 ok
- [x] `python scripts/ci_check.py` — 271 passed, ruff/mypy clean
- [ ] После мержа: следующий cron-запуск (04:00 UTC) — в Telegram-канале заголовок проекта кликабельный, отдельной строки с URL нет, превью карточки репозитория подгружается из `<a>`-ссылки

🤖 Generated with [Claude Code](https://claude.com/claude-code)