### PR TITLE
deps: bump idna to 3.15 (CVE-2026-45409)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,7 @@ filelock==3.29.0
     #   virtualenv
 identify==2.6.19
     # via pre-commit
-idna==3.13
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ httplib2==0.31.2
     #   google-api-python-client
     #   google-auth-httplib2
     #   oauth2client
-idna==3.13
+idna==3.15
     # via
     #   requests
     #   trio


### PR DESCRIPTION
## Summary

- `idna` 3.13 → 3.15 в `requirements.txt` и `requirements-dev.txt` через `pip-compile --upgrade-package idna`.
- Закрывает #103. Разблокирует #102, #104 и все будущие push'и.
- Только lockfiles — никаких code changes.

## Why

`pip-audit` падает на CVE-2026-45409 (`idna` 3.13). Advisory опубликован между последним зелёным `main` (push fa53baf, 2026-05-19 05:52 UTC) и началом проверок PR #102 (16:47 UTC).

`idna` — transitive dep (через `requests` / `urllib3` / `trio`), explicit pin в `.in` отсутствует, поэтому достаточно `--upgrade-package idna` без правки `.in` файлов.

## Test plan

- [x] `python -m pip_audit -r requirements.txt` → `No known vulnerabilities found`
- [x] Diff в обоих lockfiles исключительно `idna==3.13 → idna==3.15`; никаких других пакетов не сдвинулось.
- [x] `python scripts/ci_check.py` → all checks passed (272 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)