### PR TITLE
ci: mirror pip-audit in ci_check.py (closes #112)

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -6,7 +6,11 @@
 python scripts/ci_check.py
 ```
 
-Runs: ruff format check → ruff lint → pytest → mypy.
+Runs: ruff format check → ruff lint → pytest → test-coverage doc → pip-audit (runtime + dev) → requirements consistency → mypy.
+
+Mirrors `ci.yml` exactly — if `ci_check.py` is green, CI will be green too.
+Adds `pip-audit` (was CI-only until issue #112) and the test-coverage doc
+freshness check (CI-effectively-free; here it's enforced to avoid drift).
 
 Pre-push hook: `.githooks/pre-push` runs `ci_check.py` automatically.
 Activate: `git config core.hooksPath .githooks`

--- a/scripts/ci_check.py
+++ b/scripts/ci_check.py
@@ -46,6 +46,12 @@ def main() -> None:
         print("docs/architecture/test-coverage.md is out of date — stage it and re-run")
         sys.exit(1)
 
+    print("==> pip-audit (runtime)")
+    _run([sys.executable, "-m", "pip_audit", "-r", "requirements.txt"])
+
+    print("==> pip-audit (dev)")
+    _run([sys.executable, "-m", "pip_audit", "-r", "requirements-dev.txt"])
+
     print("==> requirements consistency")
 
     def _parse_pins(path: Path) -> dict[str, str]:


### PR DESCRIPTION
## Summary
- Добавлены `pip_audit -r requirements.txt` и `pip_audit -r requirements-dev.txt` в `scripts/ci_check.py`.
- Обновлён `docs/architecture/ci.md`: явный mirror-контракт «local ci_check == CI».

## Root cause
CI job в `.github/workflows/ci.yml` запускает `pip_audit` для обоих lockfile'ов. Локальный `ci_check.py` — нет. Поэтому уязвимый/yanked pin проходил локально, но валил CI после push'а. Это и есть основной источник цикла «push → CI fail → fix → push» (issue #112, часть #111).

## Test plan
- [x] `python scripts/ci_check.py` — green локально (295 tests, ruff/mypy/audit/consistency).
- [ ] CI на этом PR проходит без новых job'ов / шагов (только то же, что было).
- [ ] После merge: следующий PR — не должно быть рассинхрона local-pass vs CI-fail.

Refs: #111, closes #112.