### PR TITLE
feat(github): add issue + PR templates with required sections (refs #114)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Известный или подозреваемый баг — поведение системы не соответствует ожидаемому
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Заполни все секции. Они являются контрактом для `/plan #N` (структурирование плана) и `/implement #N` (исполнение с TDD red-green). Пустые секции → `/implement` откажется.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Why
+      description: Что наблюдается, кто/что страдает, чем нынешнее состояние плохо. Включи воспроизведение, если оно есть (логи, шаги, дату последнего проявления).
+      placeholder: |
+        При запуске github_trending pipeline 19.05.2026 первые 6 уведомлений в Telegram содержали обрезанные/мусорные summary_ru ("Для кого: разработчи"). Видимо для пользователей канала как «бот сломался». Воспроизводится на любом trending HTML с README markdown в description.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Что должно стать истинно после fix. Каждый bullet — testable утверждение ("при X возвращает Y"), а не "лучше работает".
+      placeholder: |
+        - При `finish_reason == MAX_TOKENS` enrich возвращает FALLBACK_MARKER, а не обрезанный текст.
+        - При ответе не матчящем `^Для кого:\s*.+\nЗачем:\s*.+` enrich возвращает FALLBACK_MARKER.
+        - `description` с markdown-шумом sanitize'ится до prompt-substitute (raw item.description не меняется).
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test plan
+      description: Конкретные тест-кейсы которые нужно написать (файл + класс + сценарий). Это контракт RED step `/implement`'а — эти тесты будут написаны первыми и упадут.
+      placeholder: |
+        - `tests/test_gemini_enricher.py::TestEnrichFallbackOnTruncation::test_max_tokens_returns_marker`
+        - `tests/test_gemini_enricher.py::TestEnrichFormatValidation::test_format_mismatch_returns_marker`
+        - `tests/test_gemini_enricher.py::TestPromptSanitization::test_markdown_noise_sanitized_in_prompt`
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation outline
+      description: Файлы и что в них меняется. По одному bullet на файл. Без полного кода — структурные изменения. Если root cause известен — укажи здесь.
+      placeholder: |
+        - `gemini_enricher.py:_generate` — читать `response.candidates[0].finish_reason`, raise `TruncatedResponse(reason)` при MAX_TOKENS/SAFETY; strip ```/`**` обёртки.
+        - `gemini_enricher.py:enrich` — sanitize `$description` (≤400 символов, без fenced blocks) до `safe_substitute`; ловить `TruncatedResponse`/format mismatch → fallback marker.
+        - `sources.json` — bump `max_tokens` 150→220.
+    validations:
+      required: true
+  - type: textarea
+    id: docs
+    attributes:
+      label: Docs to update
+      description: Какие `.md` файлы обновить в том же PR. Если behaviour не меняется снаружи — явно напиши "нет".
+      placeholder: |
+        - `docs/architecture/gemini.md` — добавить раздел про FALLBACK_MARKER contract и format validation.
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: Что НЕ делаем в этом PR (защита от scope creep). Если ничего — напиши "нет".
+      placeholder: |
+        - Изменение списка моделей в RotatingGeminiEnricher.
+        - SDK migration на `google.genai` (см. #107).
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,70 @@
+name: Feature / enhancement
+description: Новая функциональность или улучшение существующей
+title: "[feat] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Заполни все секции. Они являются контрактом для `/plan #N` (структурирование плана) и `/implement #N` (исполнение с TDD red-green). Пустые секции → `/implement` откажется.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / Why
+      description: Какую проблему/потребность это решает. Кто пользователь и в каком сценарии. Чем нынешнее состояние плохо.
+      placeholder: |
+        Сейчас github_trending не показывает «сколько звёзд за сегодня» — только total. Сложно понять, является ли репо реально trending или давно зрелым. Метрика `stars_today` уже есть в HTML, но не парсится.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Что должно стать истинно после merge. Каждый bullet — testable утверждение ("при X возвращает Y"), а не "лучше работает".
+      placeholder: |
+        - Каждое уведомление github_trending содержит "(+N today)" после `⭐ N` в message_template.
+        - При отсутствии `stars_today` в HTML — fallback "(+? today)", не пустая строка и не ошибка.
+        - Существующие тесты `tests/test_github_trending_pipeline.py` остаются зелёными.
+    validations:
+      required: true
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test plan
+      description: Конкретные тест-кейсы которые нужно написать (файл + класс + сценарий). Это контракт RED step `/implement`'а — эти тесты будут написаны первыми и упадут.
+      placeholder: |
+        - `tests/test_github_trending_pipeline.py::TestStarsToday::test_parses_stars_today_from_html`
+        - `tests/test_github_trending_pipeline.py::TestStarsToday::test_fallback_when_stars_today_absent`
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation outline
+      description: Файлы и что в них меняется. По одному bullet на файл. Без полного кода — структурные изменения.
+      placeholder: |
+        - `github_trending_pipeline.py:_extract_stars_today` — новая функция, парсит `.f6 .Link--muted` (или эквивалентный селектор).
+        - `github_trending_pipeline.py:run_*` — добавить `stars_today` в `raw` каждого item.
+        - `sources.json` — добавить `stars_today` плейсхолдер в message_template github_trending.
+    validations:
+      required: true
+  - type: textarea
+    id: docs
+    attributes:
+      label: Docs to update
+      description: Какие `.md` файлы обновить в том же PR. Если behaviour не меняется снаружи — явно напиши "нет".
+      placeholder: |
+        - `docs/architecture/pipeline.md` — упомянуть новое поле в trending raw schema.
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: Что НЕ делаем в этом PR (защита от scope creep). Если ничего — напиши "нет".
+      placeholder: |
+        - Сохранение stars_today в Google Sheets (отдельным issue если понадобится).
+        - Сортировка trending по stars_today (текущая desc по total stars остаётся).
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+PR template для kinozal_scraper. Контракт: все три секции обязательны. PR — это отчёт
+по плану из issue. Если issue нет (тривиальный фикс) — всё равно заполни все секции.
+-->
+
+## Summary
+
+<!-- 2-3 предложения: что сделано и зачем. Linker `Closes #N` (или `Refs #N`) обязателен. -->
+
+Closes #
+
+## Test plan
+
+<!--
+Markdown-чеклист. Должен зеркалить issue'шный `## Test plan` с галочками если прогнано.
+Плюс локальные команды, которые ты реально запускал.
+-->
+
+- [ ] `python scripts/ci_check.py` — green локально
+- [ ] CI на PR — green
+
+## Docs touched
+
+<!--
+Список изменённых `.md` файлов (docs/architecture/*, CLAUDE.md, MEMORY.md, …) или явно "none — behaviour unchanged". Должен зеркалить issue'шный `## Docs to update`.
+-->


### PR DESCRIPTION
## Summary

PR 1 в раскатке для #114. Добавляет GitHub issue + PR templates с обязательными секциями, на которые опираются будущие команды \`/plan #N\` и \`/implement #N\` (PR 2).

Шесть required textarea-полей в каждом issue template (Context / Acceptance / Test plan / Implementation outline / Docs to update / Out of scope) гарантируют, что user не может submit'ить incomplete issue через GitHub UI. \`config.yml\` отключает blank issues. PR template (3 секции) — отчёт по плану, зеркалит issue checklist.

Refs #114

## Test plan

- [x] \`python scripts/ci_check.py\` — green локально (templates не запускаются тестами, но pre-push отработал).
- [x] YAML syntax валиден (\`yaml.safe_load\` на оба issue форма прошёл).
- [ ] CI на PR — green.
- [ ] После merge: открыть GitHub → New Issue → проверить что bug/feature формы появляются, blank пропал, required validations работают.
- [ ] После merge: на новом PR проверить что pull_request_template подгружается в форму.

## Docs touched

none — templates are configuration, no documentation files changed.