### PR TITLE
docs(architecture): files-map.md — что-где + карта дублей (closes #152)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Issue создаём с label обязательно: `gh issue create --label b
 Key decisions recorded here; details in separate files to keep this file short.
 
 - **[Principles](docs/architecture/principles.md)** — source of truth: 6 core principles + dev workflow + quality gates. When this file conflicts with `principles.md`, `principles.md` wins.
+- [Files map](docs/architecture/files-map.md) — на какой вопрос отвечает каждый файл процесса + карта известных дублей (backlog де-дупликации)
 - [Runtime overview](docs/architecture/runtime.md) — 4 pipelines, protocols, data flow
 - [Pipeline](docs/architecture/pipeline.md) — layers, NormalizedItem, extract_from_* contracts
 - [Storage](docs/architecture/storage.md) — Storage Protocol, DI, EAFP, row schema

--- a/docs/architecture/files-map.md
+++ b/docs/architecture/files-map.md
@@ -18,8 +18,8 @@ responsibility: один файл = чёткий ответ на один воп
 | `.claude/commands/plan.md` | Как структурировать issue-body под 7 required секций (вкл. architect-review) | ✅ |
 | `.claude/commands/implement.md` | Как исполнить issue с TDD red-green (10 шагов + запреты) | ✅ |
 | `.claude/agents/architect-reviewer.md` | Персона ревьюера плана + что проверять + формат findings | ✅ |
-| `.claude/settings.json` | Что запрещено агенту (deny-list) + режим permissions | ⚠️ неполный deny-list (см. дубль #9) |
-| `.claude/settings.local.json` | Доп. локальные permissions (WebFetch / Skill) | ✅ |
+| `.claude/settings.json` (gitignored) | Что запрещено агенту (deny-list) + режим permissions | ⚠️ неполный deny-list (см. дубль #9); gitignored → не виден на GitHub |
+| `.claude/settings.local.json` (gitignored) | Доп. локальные permissions (WebFetch / Skill) | ✅ (gitignored) |
 
 ## `docs/architecture/`
 

--- a/docs/architecture/files-map.md
+++ b/docs/architecture/files-map.md
@@ -1,0 +1,67 @@
+# Files map — на какой вопрос отвечает каждый файл
+
+Навигационный/governance индекс процесса агентной разработки. Цель — single
+responsibility: один файл = чёткий ответ на один вопрос, без микса concerns и без
+дублирования фактов между файлами.
+
+**Это индекс, не контент.** Одна строка на файл; содержимое самих файлов сюда не
+копируется (иначе индекс станет ещё одним источником рассинхрона). Где факт дублируется
+сегодня — см. раздел [«Известные дубли»](#известные-дубли-и-источник-истины) (backlog
+де-дупликации, Phase B).
+
+## `.claude/` и корневые инструкции
+
+| Файл | На какой вопрос отвечает | Single-responsibility? |
+|---|---|---|
+| `~/.claude/CLAUDE.md` (глоб., вне репо) | Кто я как агент: 3 стратегических приоритета; когда subagent / скрипт / memory | ✅ |
+| `CLAUDE.md` (проект) | Микс: что делает app + Windows-граблии + резюме PR-workflow + индекс arch-доков | ❌ kitchen-sink |
+| `.claude/commands/plan.md` | Как структурировать issue-body под 7 required секций (вкл. architect-review) | ✅ |
+| `.claude/commands/implement.md` | Как исполнить issue с TDD red-green (10 шагов + запреты) | ✅ |
+| `.claude/agents/architect-reviewer.md` | Персона ревьюера плана + что проверять + формат findings | ✅ |
+| `.claude/settings.json` | Что запрещено агенту (deny-list) + режим permissions | ⚠️ неполный deny-list (см. дубль #9) |
+| `.claude/settings.local.json` | Доп. локальные permissions (WebFetch / Skill) | ✅ |
+
+## `docs/architecture/`
+
+| Файл | На какой вопрос отвечает | Single-responsibility? |
+|---|---|---|
+| `principles.md` | Микс: §I–VI принципы (часть — RUNTIME: §III Delivery, §IV Visibility) + Dev Workflow + Quality Gates + Governance | ❌ runtime-принципы + dev-process вместе |
+| `runtime.md` | Какие пайплайны / Protocols / data-flow | ✅ |
+| `pipeline.md` | Слои, контракты `extract_from_*`, `NormalizedItem` | ✅ |
+| `storage.md` | Storage Protocol, DI, row-schema, инварианты колонок | ✅ |
+| `testing.md` | Как гарантируем качество: уровни тестов, что мокать | ⚠️ дублирует principles §I/§II (дубль #4) |
+| `test-coverage.md` | Микс: bug-taxonomy + autogen-инвентарь тестов | ❌ taxonomy дублирует testing.md (дубль #5) |
+| `ci.md` | Микс: local/CI-гейты (dev-process) + production env-vars (runtime) | ❌ |
+| `gemini.md` | Gemini: model rotation / quota / retry / prompts | ✅ |
+| `files-map.md` (этот файл) | На какой вопрос отвечает каждый файл процесса + карта дублей | ✅ |
+
+## Скрипты и шаблоны процесса
+
+| Файл | На какой вопрос отвечает |
+|---|---|
+| `scripts/validate_issue_sections.py` | Содержит ли issue все 7 required секций (gate `/plan` и `/implement`) |
+| `scripts/issue_branch.py` / `scripts/new_branch.py` | Создание ветки `codex-issue-N-*` от свежего origin/main |
+| `scripts/check_red.py` | Действительно ли тесты RED перед GREEN (контракт TDD-шага) |
+| `scripts/ci_check.py` | Локальный pre-commit/pre-push гейт качества (зеркало CI job) |
+| `scripts/gen_test_coverage.py` | Генерация `test-coverage.md` (защита от drift) |
+| `.github/ISSUE_TEMPLATE/{feature,bug}.yml` | Структура нового issue (включая поле Architect review) |
+| `.github/ISSUE_TEMPLATE/config.yml` | Конфиг чузера шаблонов issue |
+| `.github/workflows/ci.yml` | Quality job на PR/push (должен зеркалить `ci_check.py`) |
+
+## Известные дубли и источник истины
+
+Backlog де-дупликации (Phase B — отдельные follow-up issue). Severity: 🔴 высокая
+(включая реальные баги-рассинхроны), 🟡 средняя, 🟢 терпимая.
+
+| # | Факт | Где продублирован | Канонический источник | Сев. |
+|---|---|---|---|---|
+| 1 | Набор required-секций issue | `validate_issue_sections.py` (tuple) + `feature.yml` + `bug.yml` + `principles.md` проза + `CLAUDE.md` проза | скрипт (tuple); остальное → ссылка | 🔴 |
+| 2 | Набор CI-проверок | `ci_check.py` vs `ci.yml` (нет coverage-drift!) vs `ci.md` («mirrors exactly» — ложь) | `ci_check.py` (**баг-рассинхрон → #153**) | 🔴 |
+| 3 | Dev-workflow правила (ветка/no-main-push/no-self-merge/one-PR/labels/plan→implement) | `CLAUDE.md` ≈ слово-в-слово `principles.md §Dev Workflow` | один источник, второй → ссылка | 🔴 |
+| 4 | Test-First + «no mocks of internal» | `principles.md §I/§II` ≈ `testing.md` | `principles.md` | 🟡 |
+| 5 | Bug taxonomy | `testing.md` ≈ `test-coverage.md` | `testing.md`; coverage.md → только инвентарь | 🟡 |
+| 6 | `codex-` префикс ветки | `new_branch.py` + `ci.yml` trigger + `principles.md` + `CLAUDE.md` | конфиг/скрипт | 🟡 |
+| 7 | `_EXCLUDE_DIRS` (mypy) | `ci_check.py` (вкл. `.audit-tmp`) vs `ci.yml` (без) — mismatch | единый источник (**→ #153**) | 🟡 |
+| 8 | Data-flow диаграмма | `runtime.md` ≈ `pipeline.md` | runtime=обзор, pipeline=деталь (терпимо) | 🟢 |
+| 9 | Запреты git (push-main/force/no-verify/pr-merge/reset/branch-D) | `implement.md` проза vs `settings.json` deny-list (неполный) | `settings.json` (энфорс) (**→ #154**) | 🟡 |
+| 10 | `pip-compile` в том же коммите | дважды внутри одного `CLAUDE.md` | один раз | 🟢 |


### PR DESCRIPTION
## Что и зачем
PR-1 из ревизии процесса агентной разработки. Создаёт `docs/architecture/files-map.md` —
живой навигационный/governance индекс: напротив каждого файла процесса (`.claude/`, scripts,
templates, CLAUDE.md) и runtime-доков записано, **на какой вопрос отвечает** его содержимое,
и помечен ли он single-responsibility или микс concerns.

Раздел «Известные дубли и источник истины» фиксирует 10 точек дублирования фактов между
файлами с указанием канонического источника и severity — это backlog де-дупликации (Phase B).
Три из них — **реальные баги-рассинхроны**, под которые заведены отдельные issue:
- #153 — `ci.yml` разошёлся с `ci_check.py` (нет coverage-drift гейта; mypy-exclude mismatch);
- #154 — `settings.json` deny-list не покрывает все запреты из `implement.md`.

## Свойства
- **Docs-only**, поведение кода не меняется (исключение §I(b) Test-First).
- Индекс держится lean: одна строка на файл, без копирования содержимого (чтобы сам индекс
  не стал ещё одним источником рассинхрона).
- Линкнут из `CLAUDE.md` → «Architecture decisions».

## Принципы
Реализует best practice «один факт — один источник истины»; не нарушает §I–VI.
Architect review: `skipped` (docs-only навигационный индекс; дизайн одобрен на этапе plan-mode).

## Verification
- `python scripts/ci_check.py` — all checks passed (360 passed, 3 skipped).
- Ручная сверка: строки таблиц соответствуют реально существующим файлам.

🤖 Generated with [Claude Code](https://claude.com/claude-code)