### PR TITLE
docs(rules): testing.md path-scoped + dedup §II ↔ testing.md (closes #160)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,11 +12,10 @@ paths:
 (уровни, bug-taxonomy, что мокать) — [`docs/architecture/testing.md`](../../docs/architecture/testing.md).
 **Не перефразируй сюда принцип — только ссылайся** (path-scoped: грузится лишь при работе с `tests/**`).
 
-1. **RED first** (§I) — сначала падающий тест из issue `## Test plan`, потом код.
-   Исключения §I(a/b/c): rename/move уже покрытого символа, docs-only, one-line non-behavioural.
-2. **Никаких моков внутренней логики** (§II) — `run_*_pipeline`/`_extract_*` вызывай напрямую;
-   внешние границы → Protocol-double (`InMemoryStorage`, `InMemoryNotifier`, `NullEnricher`)
-   или сохранённый HTML/JSON-фикстур.
+1. **RED first** — падающий тест из issue `## Test plan` пишется до кода
+   (правило и исключения — [`principles.md §I`](../../docs/architecture/principles.md)).
+2. **Никаких моков внутренней логики** — действует [`principles.md §II`](../../docs/architecture/principles.md);
+   как это выглядит в репо (какие границы внешние, какой паттерн) — [`testing.md`](../../docs/architecture/testing.md#rule-no-mocks-of-internal-functions).
 3. **Уровень теста** выбирай по [bug-taxonomy](../../docs/architecture/testing.md#bug-taxonomy)
    (integration-first → unit для pure-функций → e2e smoke перед merge для structure-drift).
 4. **Прогон** — `python -m pytest` инкрементально; перед коммитом `python scripts/ci_check.py`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "tests/**"
+---
+
+# Testing — operational checklist
+
+**На какой вопрос отвечает этот файл:** какие шаги обязательны, когда пишешь или
+правишь тесты. Это **операционный чеклист**, не дизайн-документ: формулировки
+принципов — канон в [`principles.md §I`](../../docs/architecture/principles.md) (Test-First)
+и [`§II`](../../docs/architecture/principles.md) (Protocol Boundaries + DI); стратегия
+(уровни, bug-taxonomy, что мокать) — [`docs/architecture/testing.md`](../../docs/architecture/testing.md).
+**Не перефразируй сюда принцип — только ссылайся** (path-scoped: грузится лишь при работе с `tests/**`).
+
+1. **RED first** (§I) — сначала падающий тест из issue `## Test plan`, потом код.
+   Исключения §I(a/b/c): rename/move уже покрытого символа, docs-only, one-line non-behavioural.
+2. **Никаких моков внутренней логики** (§II) — `run_*_pipeline`/`_extract_*` вызывай напрямую;
+   внешние границы → Protocol-double (`InMemoryStorage`, `InMemoryNotifier`, `NullEnricher`)
+   или сохранённый HTML/JSON-фикстур.
+3. **Уровень теста** выбирай по [bug-taxonomy](../../docs/architecture/testing.md#bug-taxonomy)
+   (integration-first → unit для pure-функций → e2e smoke перед merge для structure-drift).
+4. **Прогон** — `python -m pytest` инкрементально; перед коммитом `python scripts/ci_check.py`.
+5. **Структура тестов изменилась** (новый файл/класс) — `test-coverage.md` регенерится
+   `ci_check`'ом (`python scripts/gen_test_coverage.py`); инвентарь руками не правь.

--- a/docs/architecture/project-map.md
+++ b/docs/architecture/project-map.md
@@ -75,6 +75,7 @@ docstring для `.py`, верхняя строка-шапка для `.md`. Hea
 | `~/.claude/CLAUDE.md` (глоб., вне репо) | Кто я как агент: кросс-проектные приоритеты; когда subagent / скрипт / memory | ✅ |
 | `CLAUDE.md` (проект) | Микс: что делает app + Windows-граблии + резюме PR-workflow + индекс arch-доков | ❌ kitchen-sink |
 | `.claude/rules/workflow.md` | Процедурные правила workflow (ветка/PR-дисциплина/labels/plan→implement/гейты) — канон, always-load | ✅ |
+| `.claude/rules/testing.md` | Операционный чеклист написания тестов (RED-first/doubles/уровень/ci_check) — path-scoped `tests/**`, ссылается на §I/§II | ✅ |
 | `.claude/commands/plan.md` | Как структурировать issue-body под 7 required секций (вкл. architect-review) | ✅ |
 | `.claude/commands/implement.md` | Как исполнить issue с TDD red-green (10 шагов + запреты) | ✅ |
 | `.claude/agents/architect-reviewer.md` | Персона ревьюера плана + что проверять + формат findings | ✅ |
@@ -90,7 +91,7 @@ docstring для `.py`, верхняя строка-шапка для `.md`. Hea
 | `runtime.md` | Какие пайплайны / Protocols / data-flow | ✅ |
 | `pipeline.md` | Слои, контракты `extract_from_*`, `NormalizedItem` | ✅ |
 | `storage.md` | Storage Protocol, DI, row-schema, инварианты колонок | ✅ |
-| `testing.md` | Как гарантируем качество: уровни тестов, что мокать | ⚠️ дублирует principles §I/§II (дубль #4) |
+| `testing.md` | Как гарантируем качество: уровни тестов, что мокать (ссылается на `principles.md §II`, не дублирует) | ✅ |
 | `test-coverage.md` | Микс: bug-taxonomy + autogen-инвентарь тестов | ❌ taxonomy дублирует testing.md (дубль #5) |
 | `ci.md` | Микс: local/CI-гейты (dev-process) + production env-vars (runtime) | ❌ |
 | `gemini.md` | Gemini: model rotation / quota / retry / prompts | ✅ |
@@ -141,8 +142,8 @@ Backlog де-дупликации. Severity: 🔴 высокая (включая
 | 1 | Набор required-секций issue | `validate_issue_sections.py` (tuple) + `feature.yml` + `bug.yml` + `principles.md` проза + ~~`CLAUDE.md` проза~~ (убрана #159) | скрипт (tuple); остальное → ссылка | 🔴 частично |
 | 2 | Набор CI-проверок | `ci_check.py` vs `ci.yml` (нет coverage-drift!) vs `ci.md` («mirrors exactly» — ложь) | `ci_check.py` (**баг-рассинхрон → #153**) | 🔴 |
 | 3 | ~~Dev-workflow правила (ветка/no-main-push/no-self-merge/one-PR/labels/plan→implement)~~ | ✅ закрыт #159: канон = `.claude/rules/workflow.md` (always-load); `principles.md §Dev Workflow` и `CLAUDE.md §PR Workflow` → указатели; §Governance легализует делегирование | `.claude/rules/workflow.md` | ✅ |
-| 4 | Test-First + «no mocks of internal» | `principles.md §I/§II` ≈ `testing.md` | `principles.md` | 🟡 |
-| 5 | Bug taxonomy | `testing.md` ≈ `test-coverage.md` | `testing.md`; coverage.md → только инвентарь | 🟡 |
+| 4 | ~~Test-First + «no mocks of internal»~~ | ✅ закрыт #160: канон = `principles.md §II`; `testing.md` → указатель «Canon: §II» (не перефраз); операционный чеклист → `.claude/rules/testing.md` (path-scoped) | `principles.md §II` | ✅ |
+| 5 | Bug taxonomy | `test-coverage.md` ссылается на `testing.md#bug-taxonomy` как канон (keyed, без колонки Examples — не перефраз) | `testing.md` | ✅ resolved-by-link |
 | 6 | `codex-` префикс ветки | `new_branch.py` + `ci.yml` trigger + `principles.md` + `CLAUDE.md` | конфиг/скрипт | 🟡 |
 | 7 | `_EXCLUDE_DIRS` (mypy) | `ci_check.py` (вкл. `.audit-tmp`) vs `ci.yml` (без) — mismatch | единый источник (**→ #153**) | 🟡 |
 | 8 | Data-flow диаграмма | `runtime.md` ≈ `pipeline.md` | runtime=обзор, pipeline=деталь (терпимо) | 🟢 |

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -6,16 +6,13 @@
 
 ## Rule: no mocks of internal functions
 
-> **Canon:** this rule is the operational elaboration of [principles.md §II](principles.md)
-> (Protocol Boundaries with Dependency Injection). The binding statement lives there;
-> below is project-specific detail, not a restatement.
+> **Canon:** the binding statement is [principles.md §II](principles.md) (Protocol
+> Boundaries with Dependency Injection). This section is the project-specific
+> elaboration: which boundaries count as external here, and the concrete pattern to follow.
 
-Mock of external I/O is acceptable. Mock of internal business logic is not.
-
-- External boundaries (Sheets, Telegram, YouTube, HTTP) → Fake implementation
-  (`InMemoryStorage`, `InMemoryNotifier`) or a saved HTML/JSON fixture.
-- Internal functions (`_extract_kinozal_items`, `run_kinozal_pipeline`, etc.)
-  → NEVER mock. Tests must call the production function directly.
+In this repo the external boundaries are Sheets, Telegram, YouTube and HTTP — substitute a
+Fake (`InMemoryStorage`, `InMemoryNotifier`) or a saved HTML/JSON fixture. Everything else
+(`_extract_kinozal_items`, `run_kinozal_pipeline`, …) is internal and is never mocked (§II).
 
 **Correct pattern (as in `test_json_pipeline.py`):**
 Call `run_*_pipeline()` directly. Pass `InMemoryStorage` and `InMemoryNotifier`.

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -6,18 +6,16 @@
 
 ## Rule: no mocks of internal functions
 
+> **Canon:** this rule is the operational elaboration of [principles.md §II](principles.md)
+> (Protocol Boundaries with Dependency Injection). The binding statement lives there;
+> below is project-specific detail, not a restatement.
+
 Mock of external I/O is acceptable. Mock of internal business logic is not.
 
-**Rule:**
 - External boundaries (Sheets, Telegram, YouTube, HTTP) → Fake implementation
   (`InMemoryStorage`, `InMemoryNotifier`) or a saved HTML/JSON fixture.
 - Internal functions (`_extract_kinozal_items`, `run_kinozal_pipeline`, etc.)
   → NEVER mock. Tests must call the production function directly.
-
-**Anti-pattern (to remove in step 2):**
-`_FetchingPipeline` in `test_kinozal_pipeline.py` duplicates `run_kinozal_pipeline`
-inside the test. If production deduplication logic changes, the test stays green —
-it tests its own copy.
 
 **Correct pattern (as in `test_json_pipeline.py`):**
 Call `run_*_pipeline()` directly. Pass `InMemoryStorage` and `InMemoryNotifier`.


### PR DESCRIPTION
## Summary

PR-3 серии приведения файлов к официальной tier-модели Claude Code (#158–#162). Убивает дубль #4: правило «no mocks of internal functions» больше не перефразируется в `testing.md` (теперь указатель «Canon: §II»), и задействует path-scoped `.claude/rules/testing.md` — операционный чеклист, грузящийся в контекст только при работе с `tests/**`. Дубль #5 закрыт «resolved-by-link».

Closes #160

## Test plan

- [x] `python scripts/ci_check.py` — green локально (366 passed, 3 skipped; ruff/mypy/pip-audit/coverage-drift OK)
- [ ] CI на PR — green
- docs/instruction-only PR (§I исключение (b)) — автотестов нет, behaviour кода не меняется
- Проверено: `_FetchingPipeline` отсутствует в `tests/` (мёртвый anti-pattern удалён, S2); `paths:`-frontmatter по официальному спеку `code.claude.com/docs/en/memory`

## Docs touched

- `.claude/rules/testing.md` (new, path-scoped `tests/**`)
- `docs/architecture/testing.md` (canon-pointer на §II, удалён мёртвый anti-pattern)
- `docs/architecture/project-map.md` (дубли #4/#5 → ✅, новая строка rules/testing.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
