### PR TITLE
chore(ci): удалить codex-* push-триггер после слива legacy-PR (#170)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
       - "issue-*"
-      # transition: remove once no open PRs on codex-* (gh pr list) — see #170
-      - "codex-*"
 
 jobs:
   quality:

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -23,8 +23,7 @@ Activate: `git config core.hooksPath .githooks`
 
 ## CI workflow (`ci.yml`)
 
-Triggers: PR and push to `main` / `issue-*` branches. (Transition: `codex-*`
-is also triggered until legacy `codex-*` PRs drain — removed in #170.)
+Triggers: PR and push to `main` / `issue-*` branches.
 
 Steps: checkout → Python 3.12 → install deps → then one
 `python scripts/ci_check.py --only <name>` step per registry check (format,


### PR DESCRIPTION
## Summary

Follow-up к #162. Переходный двойной push-триггер (`issue-*` + `codex-*`) больше не нужен — `gh pr list --state open` не содержит открытых `codex-*` head-веток. Удалена строка `- "codex-*"` из `ci.yml` `push.branches` + transition-комментарий; `ci.md` transition-нота приведена к финальному состоянию (только `issue-*`).

Closes #170

## Test plan

Тривиальная правка конфигурации (одна строка + комментарий + doc-нота), runtime-кода не касается.

- [x] `python scripts/ci_check.py` — green локально
- [x] Gate-условие проверено: `gh pr list --state open` → 0 открытых `codex-*` PR
- [ ] CI на PR — green (сам этот PR на `issue-*` ветке проверяет, что триггер не сломан)

## Docs touched

- `.github/workflows/ci.yml` (push.branches)
- `docs/architecture/ci.md` (transition-нота → финал)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
