### PR TITLE
docs(ia): README §Architecture — свернуть параллельный индекс доков в указатель (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,8 @@ Configuration (env vars, secrets, CI workflows) is documented in [docs/architect
 
 ## Architecture
 
-See [docs/architecture/](docs/architecture/) for detailed design docs:
-
-- [Runtime overview](docs/architecture/runtime.md) — pipelines, protocols, data flow
-- [Pipeline](docs/architecture/pipeline.md) — layers, NormalizedItem, notification templates
-- [Storage](docs/architecture/storage.md) — Storage Protocol, DI, row schema
-- [Testing](docs/architecture/testing.md) — no mocks on external APIs, Protocol doubles
-- [Test coverage](docs/architecture/test-coverage.md) — what is tested, gaps
-- [CI & deployment](docs/architecture/ci.md) — GitHub Actions, env vars, setup
-- [Gemini enrichment](docs/architecture/gemini.md) — model rotation, quota strategy
+See [docs/architecture/](docs/architecture/) for detailed design docs.
+Full file-by-file index (what each file answers) → [project-map.md](docs/architecture/project-map.md).
 
 ## Regenerate pinned dependencies
 


### PR DESCRIPTION
Closes #181.

## Зачем

После #179/#180 навигация по докам — одно-родительское дерево (`CLAUDE.md` → `project-map.md` → доки). Но `README.md §Architecture` вёл **третий параллельный индекс** тех же 7 deep-dive доков, **уже дрейфовавший**: pipeline-хук README («notification templates») расходился с каноном `project-map.md` («`extract_from_*` contracts»).

## Что сделано (docs-only)

- `README.md §Architecture`: 7 per-doc буллетов (`Runtime`…`Gemini`) → указатель: browsable `docs/architecture/` + `project-map.md` как полный file-by-file индекс. Третья копия списка устранена → источник дрейфа исчез.

## Public-аудитория (митигация)

README читает публичный посетитель GitHub, `project-map.md` агент-ориентирован (колонки SR, tier-модель). Чтобы front-page не страдал, указатель ведёт **в первую очередь** на browsable `docs/architecture/` (нормальный landing), и лишь дополнительно — на полный индекс.

## Out of scope

- Reference-слой (canonical-home keyed-ссылки) — не трогаем.
- Обратная пометка в `project-map.md` — не добавляем (containment-стрелка односторонняя).

## Тесты

Автотеста нет — docs-only, ни один тест не утверждает README-контент (§IV-позиция: семантический dup/link-детектор не строим). `ci_check.py` зелёный; per-doc список в README отсутствует.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
