### PR TITLE
docs(ia): зеркало kinozal.guru → репо рядом с knob URLS (closes #187)

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -124,18 +124,19 @@ Steps run sequentially:
 | Variable | Type | Purpose |
 |---|---|---|
 | `API_KEY` | secret | Kinozal API key |
-| `URLS` | var | Kinozal page URLs to scrape (override; default — `base_url` из `sources.json` + `/top.php`) |
+| `URLS` | var | Kinozal page URLs to scrape, формат `label\|url;...`; local fallback — env `KINOZAL_TOP_URL` (plain url). Если не задано ни то ни другое — pipeline логирует ошибку `no URLs configured`. `sources.json` `url`/`base_url` для скрейпинга **не читается** (только schema-placeholder), см. `kinozal_pipeline.py::_kinozal_urls` |
 
 > **Зеркало при 520/недоступности `kinozal.tv`:** рабочее зеркало — **`kinozal.guru`**
-> (та же структура страниц). При даунтайме основного домена ставь
-> `URLS=https://kinozal.guru/top.php`. `sources.json` `base_url` остаётся `https://kinozal.tv`
-> (canonical origin) — зеркало применяется **только** через `URLS`, в `sources.json` его не
-> прописывать (иначе production-origin уедет на зеркало навсегда).
+> (та же структура страниц). При даунтайме основного домена переключи на зеркало `URLS`,
+> сохраняя формат `label|url;...` (например `URLS=Кинозал|https://kinozal.guru/top.php`); для
+> локального прогона проще `KINOZAL_TOP_URL=https://kinozal.guru/top.php` (plain url, fallback).
+> `sources.json` `base_url` остаётся `https://kinozal.tv` (canonical origin) — в `sources.json`
+> зеркало не прописывать.
 >
 > Сейчас потребитель — production-cron (`run-script.yml` / `kinozal_pipeline.py`). E2E
 > `tests/test_e2e_kinozal_titles.py` станет вторым потребителем после #136 (тест безусловно
-> skip'нут, пока `kinozal.tv` отдаёт 520); его fallback-ветка на `base_url` зеркало не
-> покрывает — это ожидаемо.
+> skip'нут, пока `kinozal.tv` отдаёт 520); там зеркало надо задавать через `URLS`/`KINOZAL_TOP_URL`,
+> т.к. собственная fallback-ветка теста на `base_url` ведёт на `kinozal.tv` — это ожидаемо.
 
 ### telegram_summarizer
 

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -124,7 +124,18 @@ Steps run sequentially:
 | Variable | Type | Purpose |
 |---|---|---|
 | `API_KEY` | secret | Kinozal API key |
-| `URLS` | var | Kinozal page URLs to scrape |
+| `URLS` | var | Kinozal page URLs to scrape (override; default — `base_url` из `sources.json` + `/top.php`) |
+
+> **Зеркало при 520/недоступности `kinozal.tv`:** рабочее зеркало — **`kinozal.guru`**
+> (та же структура страниц). При даунтайме основного домена ставь
+> `URLS=https://kinozal.guru/top.php`. `sources.json` `base_url` остаётся `https://kinozal.tv`
+> (canonical origin) — зеркало применяется **только** через `URLS`, в `sources.json` его не
+> прописывать (иначе production-origin уедет на зеркало навсегда).
+>
+> Сейчас потребитель — production-cron (`run-script.yml` / `kinozal_pipeline.py`). E2E
+> `tests/test_e2e_kinozal_titles.py` станет вторым потребителем после #136 (тест безусловно
+> skip'нут, пока `kinozal.tv` отдаёт 520); его fallback-ветка на `base_url` зеркало не
+> покрывает — это ожидаемо.
 
 ### telegram_summarizer
 


### PR DESCRIPTION
## Summary

Зеркало `kinozal.tv` — `kinozal.guru` — жило только в out-of-repo Claude-памяти
(`reference_kinozal_mirror`), при переезде/клоне терялось. Перенесено в репо: примечание к
существующему env-override `URLS` в `docs/architecture/ci.md` — при 520/недоступности основного
домена ставить `URLS=https://kinozal.guru/top.php`. `sources.json` `base_url` остаётся
`kinozal.tv` (origin не уезжает на зеркало). Часть декомпозиции #186 (architect-review §4).

Closes #187
Related: #136

## Test plan

- [x] `python scripts/ci_check.py` — green локально (ruff/pytest 383✓/pip-audit runtime+dev/mypy)
- [ ] CI на PR — green
- [x] Issue Test plan: автотестов нет (docs-only, behaviour кода не меняется); knob `URLS` —
      существующий механизм, его поведение не трогается; sync-тест дублей не строим
      (`project-map` §IV / `feedback_eliminate_dup_over_guard`)

## Docs touched

- `docs/architecture/ci.md` — примечание про зеркало рядом с knob `URLS` (единственный
  изменённый файл; `runtime.md` не трогаем — keyed-ссылку не плодим, дом один)
