### PR TITLE
docs(workflow): 3 workflow-дисциплины из памяти в репо (#189)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -20,8 +20,16 @@ git-запреты — в `.claude/settings.json` `permissions.deny`).
    merge button.
 4. **One PR, one logical unit** — docs-only PRs are separate from
    refactor/feature PRs (precedent: #39 → #40 had to be redone after mixing).
+   **Pragmatic exception:** a *temporary* CI unblock of an **unrelated**
+   failing test (e.g. an E2E reddening a docs-PR via an external 520) goes
+   into the branch being merged — with a **tracked follow-up issue** for the
+   real fix — not a separate off-main PR (that costs an extra merge+rebase
+   round-trip). Permanent changes are still split.
 5. **Issues carry labels** — every `gh issue create` includes `--label
-   bug|enhancement|documentation|testing|...`.
+   bug|enhancement|documentation|testing|...`. Semantics: `bug` = something
+   broken / current behaviour wrong; `enhancement` = improvement / new feature
+   / quality; `documentation` = `*.md`/`docs/`-only; `testing` = test-coverage
+   work. Full set: `gh label list` (don't hard-code the list here — it drifts).
 6. **Pre-commit gate** — `python scripts/ci_check.py` runs ruff format +
    lint + pytest + mypy + pip-audit + lockfile drift. The `.githooks/pre-push`
    hook runs it automatically; do not bypass with `--no-verify`.
@@ -51,3 +59,16 @@ git-запреты — в `.claude/settings.json` `permissions.deny`).
    reviewer persona used to live in out-of-repo Claude memory and was
    re-typed by hand and easily forgotten; codifying it in-repo + gating it
    makes the review reproducible for any contributor (#150).
+10. **Dedup check before issue creation** — before `gh issue create`, run
+    `git fetch` and scan recently-merged PRs / recently-closed issues for the
+    same topic (`git log --oneline origin/main -10`, `gh issue list --state
+    closed --limit 10`); if it overlaps, open that PR/issue and check scope
+    before filing. **Prose, not a gate, on purpose:** the deterministic half
+    (`git fetch`) is one command, but judging *topic overlap* is a semantic
+    call — the same class as the semantic-dup detector we deliberately don't
+    build (`docs/architecture/project-map.md`) — so a script wouldn't remove
+    the human step and a gate doesn't pay off. `scripts/new_branch.py` only
+    pulls fresh main at branch time, too late to catch the duplicate.
+    **Precedent:** #125 re-filed the `validate_issue_sections.py` UTF-8/cp1252
+    bug already fixed in merged PR #123 (`e1548385`, closing #122); the
+    duplicate had to be closed by hand.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -23,8 +23,8 @@ git-запреты — в `.claude/settings.json` `permissions.deny`).
    **Pragmatic exception:** a *temporary* CI unblock of an **unrelated**
    failing test (e.g. an E2E reddening a docs-PR via an external 520) goes
    into the branch being merged — with a **tracked follow-up issue** for the
-   real fix — not a separate off-main PR (that costs an extra merge+rebase
-   round-trip). Permanent changes are still split.
+   real fix — not a separate standalone fix PR (that costs an extra
+   merge+rebase round-trip). Permanent changes are still split.
 5. **Issues carry labels** — every `gh issue create` includes `--label
    bug|enhancement|documentation|testing|...`. Semantics: `bug` = something
    broken / current behaviour wrong; `enhancement` = improvement / new feature


### PR DESCRIPTION
## Summary

Переносит 3 из 4 workflow-дисциплин из out-of-repo памяти в канон `.claude/rules/workflow.md`
(always-load), чтобы пережили переезд (Memory→repo, прецедент #150). 4-я
(`eliminate_dup_over_guard`) не переносится — полностью покрыта `project-map.md §IV`
(canonical-home + «детектор не строим»).

- **§4** — прагматичное исключение one-PR-one-unit: временный анблок CI от постороннего падающего
  теста → в мержимую ветку с трекнутым follow-up, не отдельным PR.
- **§5** — семантика меток (`bug`/`enhancement`/`documentation`/`testing`) + указатель на
  `gh label list` вместо вшитого перечня (динамика → дрейф).
- **§10** (новое) — fetch-before-issue: явный детерминированный шаг (`git fetch` + просмотр recent
  PR/closed issue) + встроенное обоснование «почему проза, не гейт» (суждение о пересечении тем
  семантическое). Прецедент выверен: #125 = дубль UTF-8-бага, уже в смерженном PR #123 (`e1548385`).

Чистый docs-only, поведение кода не меняется.

Closes #189

## Test plan

- [x] `python scripts/ci_check.py` — green локально (383 passed, 3 skipped)
- [ ] CI на PR — green

Автоматического RED нет — docs-only (§I exception); корректность правил / отсутствие дубля
(§10 vs «скрипты > инструкции», eliminate_dup vs project-map) проверяет человек на ревью.

## Docs touched

- `.claude/rules/workflow.md` (§4 исключение, §5 таксономия, §10 новое правило)

## Post-merge follow-up (ручной шаг — не забыть на мерже)

- [ ] Удалить из `~/.claude/.../memory/` + снять строки из `MEMORY.md`:
      `feedback_fetch_before_issue`, `feedback_unblock_in_same_branch`, `feedback_issue_labels`
      (перенесены) + `feedback_eliminate_dup_over_guard` (покрыт project-map).
