### PR TITLE
Сдвинуть запуск на час раньше + убрать дубль времени из доков

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,7 +1,7 @@
 name: Run python script
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch:
 jobs:
   run-script:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # kinozal_scraper — контекст для Claude
 
 ## Что делает приложение
-Парсит топ kinozal.tv по расписанию (GitHub Actions, 04:00 UTC), дедуплицирует через Google Sheets, отправляет новинки в Telegram. Параллельно суммаризует Telegram-каналы через Gemini.
+Парсит топ kinozal.tv по расписанию (GitHub Actions, cron в `.github/workflows/run-script.yml`), дедуплицирует через Google Sheets, отправляет новинки в Telegram. Параллельно суммаризует Telegram-каналы через Gemini.
 
 ## Среда
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Multi-source notification pipeline that monitors Kinozal, GitHub, Steam, and Soldout for new content, deduplicates via Google Sheets, and sends alerts to Telegram. Also summarizes Telegram channels via Gemini.
 
-Runs daily at 04:00 UTC via GitHub Actions.
+Runs daily via GitHub Actions (schedule in `.github/workflows/run-script.yml`).
 
 ## Sources
 

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -75,7 +75,7 @@ No separate Anthropic API billing — usage counts against the Pro/Max subscript
 
 ## Production workflow (`run-script.yml`)
 
-Schedule: `0 4 * * *` UTC + manual `workflow_dispatch`.
+Schedule: daily cron (UTC) defined in `run-script.yml` + manual `workflow_dispatch`.
 
 Steps run sequentially:
 1. **pytest** — smoke gate, fails fast

--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -127,8 +127,8 @@ fields, mismatched sheet schemas.
 class of config error becomes possible, the validator MUST grow a check for
 it in the same PR.
 
-**Rationale:** every config-validation gap shows up at 04:00 UTC in cron
-logs, days after the typo was introduced. Catching it on `python
+**Rationale:** every config-validation gap shows up in the daily cron
+run, days after the typo was introduced. Catching it on `python
 pipeline_config.py` (or in ci_check) keeps the feedback loop human-scale.
 
 ## Development Workflow

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -4,12 +4,12 @@
 
 | Entry point | Sources | Type | Schedule |
 |---|---|---|---|
-| `json_pipeline.py` | GitHub `new_popular` | JSON API | daily 04:00 UTC |
-| `github_trending_pipeline.py` | GitHub trending | HTML scraping + Gemini | daily 04:00 UTC |
-| `steam_pipeline.py` | Steam Most Played | JSON (Steam Charts + appdetails) | daily 04:00 UTC |
-| `events_pipeline.py` | Soldout events | HTML scraping | daily 04:00 UTC |
-| `kinozal_pipeline.py` | Kinozal movies | HTML scraping | daily 04:00 UTC |
-| `telegram_summarizer.py` | Telegram channels | Gemini summarization | daily 04:00 UTC, `if: always()` |
+| `json_pipeline.py` | GitHub `new_popular` | JSON API | daily |
+| `github_trending_pipeline.py` | GitHub trending | HTML scraping + Gemini | daily |
+| `steam_pipeline.py` | Steam Most Played | JSON (Steam Charts + appdetails) | daily |
+| `events_pipeline.py` | Soldout events | HTML scraping | daily |
+| `kinozal_pipeline.py` | Kinozal movies | HTML scraping | daily |
+| `telegram_summarizer.py` | Telegram channels | Gemini summarization | daily, `if: always()` |
 
 All pipelines except `telegram_summarizer` follow the generic pipeline
 pattern. `telegram_summarizer` uses `TelegramChannelSummarizer` (Telethon


### PR DESCRIPTION
Closes #198.

## Что меняется
- `run-script.yml`: cron `0 4 * * *` → `0 3 * * *` (UTC), запуск на час раньше.
- Убрано дублирование конкретного времени в доках (README/CLAUDE/ci/principles/runtime) — теперь они ссылаются на `run-script.yml` как на единственный источник истины. Будущий сдвиг расписания правится в одном месте.

## Почему дедуп в том же PR
Время было продублировано в 6 местах; смена в одном требовала ручной синхронизации остальных (что и вскрылось при этой правке). Устранение дубля — та же логическая единица «расписание», поэтому не выделялось в отдельный PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)