### PR TITLE
chore(deps): bump msgpack 1.1.2 → 1.2.1 (dev) — fix GHSA-6v7p-g79w-8964

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -54,7 +54,7 @@ markdown-it-py==4.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-msgpack==1.1.2
+msgpack==1.2.1
     # via cachecontrol
 mypy==1.20.2
     # via -r requirements-dev.in


### PR DESCRIPTION
## Что

`pip-audit (dev)` краснел на транзитивном `msgpack==1.1.2` (GHSA-6v7p-g79w-8964, fix: 1.2.1). Бамп до 1.2.1.

`msgpack` тянется транзитивно (`cachecontrol` → `pip-audit`), прямого pin в `requirements-dev.in` нет.

## Как

`pip-compile --upgrade-package msgpack --output-file=requirements-dev.txt requirements-dev.in` — изменилась **только** строка pin, остальной lockfile нетронут.

## Проверка

`python scripts/ci_check.py` — green (обе pip-audit runtime+dev: «No known vulnerabilities found»).

Предсуществующий red на main, не связан с конкретной фичей — отдельный fix-PR, чтобы не мешать в docs/конфиг-PR (one-PR-one-unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)