### PR TITLE
docs(testing): раздел «когда тест НЕ писать» (ROI / change-detector / 4 типа изменений)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -14,6 +14,9 @@ paths:
 
 1. **RED first** — падающий тест из issue `## Test plan` пишется до кода
    (правило и исключения — [`principles.md §I`](../../docs/architecture/principles.md)).
+   Но прежде — **стоит ли тест писать вообще:** регресс ломает корректность/безопасность
+   (→ тест) или только тратит ресурсы CI-минут/токенов (→ forcing-function, не guard-тест)?
+   Канон — [`testing.md`](../../docs/architecture/testing.md#rule-when-a-test-is-not-worth-writing).
 2. **Никаких моков внутренней логики** — действует [`principles.md §II`](../../docs/architecture/principles.md);
    как это выглядит в репо (какие границы внешние, какой паттерн) — [`testing.md`](../../docs/architecture/testing.md#rule-no-mocks-of-internal-functions).
 3. **Уровень теста** выбирай по [bug-taxonomy](../../docs/architecture/testing.md#bug-taxonomy)

--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -22,7 +22,9 @@ to make them GREEN (see #114).
 Exceptions, all narrow: (a) rename / move of an already-tested symbol, (b)
 documentation-only PRs, (c) one-line non-behavioural fixes (typos, comments).
 Anything that changes what the code *does* needs a test that would have caught
-the prior behaviour.
+the prior behaviour. The converse — when a *non-behavioural* regression still
+does not earn a guard test (a resource-only cost, not correctness/safety) — is
+in [testing.md](testing.md#rule-when-a-test-is-not-worth-writing).
 
 A test that pins a known production bug (`TestConfigValidationKnownGaps` style)
 is allowed only when an issue tracks the fix; when fixed, the test MUST be

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -84,6 +84,53 @@ Choose the cheapest reliable test for each category.
 - `TelegramChannelSummarizer` / Telethon calls.
 - Any code path that requires live credentials.
 
+> **Scope-skip vs cost-skip.** The list above is a *scope* skip — those paths can't run
+> without live credentials. The rule below is a *cost* skip — the code is perfectly
+> testable, but a test wouldn't pay for itself.
+
+## Rule: when a test is NOT worth writing
+
+Not every regression deserves a test. Decide by what the regression actually breaks:
+
+- **Correctness or safety regression → write the test.** A wrong row, a dropped item, a
+  leaked secret, a broken import — the test guards a real failure mode (e.g.
+  `test_repo_layout` guards import correctness, `test_settings_deny` guards a security
+  invariant).
+- **Resource-only regression (CI minutes, tokens) → no guard test; use a forcing-function
+  instead** (a doc note, a deny-list, a config gate). A test here costs maintenance plus CI
+  time to guard something that, if it regresses, only ever wastes CI time — net negative
+  (goal-function priority (2), [mindset.md](../../.claude/rules/mindset.md)).
+
+**Precedent (#207):** a duplicate CI run (one `quality` job fired by both `pull_request`
+and a `push: issue-*` event for the same commit) wasted CI minutes. The fix was a one-line
+trigger removal; a guard test asserting "no duplicate trigger" was added, then removed as
+work-for-work — the regression it guarded cost only CI minutes, not correctness. The
+forcing-function lives in [ci.md](ci.md) ("do not re-add `issue-*` to push") instead.
+
+## Rule: test behaviour, not implementation
+
+Test through the public entry point (`run_*_pipeline()`) and assert on observable **state**,
+never on which internal methods were called in which order. A test that mirrors the
+implementation is a *change-detector*: it breaks on every refactor without catching a bug —
+**negative value**. The aim is an *unchanging* test that fails only when behaviour actually
+changes. This is the positive framing of [§II no-internal-mocks](principles.md): mocking an
+internal function is the most common way a test ends up asserting interaction instead of
+state.
+
+### Change type → test response
+
+| Change | Test response |
+|---|---|
+| Pure refactor (behaviour identical) | Tests unchanged — if they break, they were change-detectors |
+| New feature | Add new tests only; existing tests stay green |
+| Bug fix | Add a case reproducing the bug, then fix |
+| Behaviour change | Change the tests deliberately (this is the signal, not noise) |
+
+The "behaviour change needs a test" half is canon in [principles.md §I](principles.md)
+(Test-First) — see its exceptions for what legitimately skips a test (rename/move,
+docs-only, one-line non-behavioural). This table is the refactor-vs-feature companion to §I,
+not a restatement of it.
+
 ## Test runner
 
 ```bash


### PR DESCRIPTION
## Что и зачем
Дополняет тест-инструкции репо разделом «когда тест НЕ писать» — закрывает пробел, вскрытый ретро #207 (убранный guard-тест на регресс ценой лишь CI-минут). Раньше доки отвечали «**какой** тест для **какого** бага», но молча предполагали, что тест должен существовать, и не запрещали change-detector тесты.

## Изменения (docs-only)
- **`docs/architecture/testing.md`** — рядом со scope-based `## What does NOT get tested` добавлено cost-based правило `## Rule: when a test is NOT worth writing` (корректность/безопасность → тест; resource-only регресс → forcing-function, прецедент #207) + строка-разграничение scope-skip vs cost-skip; `## Rule: test behaviour, not implementation` (no change-detector, unchanging-test, state-not-interaction — позитивная рамка §II) + таблица «change type → test response» с кросс-ссылкой на §I.
- **`docs/architecture/principles.md §I`** — строка-кросс-ссылка на cost-skip правило.
- **`.claude/rules/testing.md`** — строка чеклиста «стоит ли тест писать вообще» перед RED-шагом.

## Test plan
Поведение кода не меняется → новых pytest-тестов нет (`principles.md §I` исключение (b) docs-only). Добавить тест на прозу = нарушить ровно то правило, что документируем. Гейт `python scripts/ci_check.py` — зелёный (384 passed, 3 e2e skip).

## Architect review
Прогон субагента `architect-reviewer` по плану: **0 BLOCKING**. Два SHOULD-FIX вплетены до коммита — (1) уточнено, что в `ci.md` лежит конфиг-forcing-function, а не тест-дизайн-урок (его дом — теперь этот PR); (2) ROI-правило поставлено рядом со scope-based секцией с явным разграничением, не третьей параллельной «что не тестируем». NICE: «4 change-types» кросс-линкует §I, не дублирует.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
