### PR TITLE
docs(testing): mutation+coverage аудит — equivalent-mutant caveat + scope/cost-skip учёт (closes #219)

### DIFF
--- a/docs/architecture/test-coverage.md
+++ b/docs/architecture/test-coverage.md
@@ -37,7 +37,41 @@ row promoted to ✅.
 | Module | Reason | Mitigation |
 |---|---|---|
 | `youtube.py` | No Protocol boundary, requires live YouTube API | Indirect coverage via `test_kinozal_pipeline.py::TestEnrichWithTrailer` |
-| `text_utils.py` | Small utility | Indirect coverage via `test_kinozal_pipeline.py::TestTitleYearMatches` |
+| `text_utils.py` | Small utility | Indirect coverage via `test_kinozal_pipeline.py::TestTitleYearMatches` — **mutation-verified** (audit below: 0 survivors, the indirect coverage is real, not for-show) |
+| `*_pipeline.py` `if __name__ == "__main__"` blocks | CLI wiring of live `gspread`/env (`json`/`kinozal`/`events`/`github_trending`/`steam`) — needs live credentials | **Scope-skip**, exercised by the daily cron (§IV «cron = E2E smoke»): a wiring break → red CI / zero-row next run. The large uncovered blocks in the `coverage.py` map are these `__main__` runners, not logic gaps |
+| `crypto.py` (`crypto.save_/load_encrypter_session`) | File-IO glue (read/write `secret.key`/`anon.session*`) around the **tested** pure helpers `encrypt_bytes`/`decrypt_bytes` | **Cost-skip**: mocking the filesystem to guard trivial glue is negative-ROI; failure is loud (`KeyError`/`InvalidToken` crashes cron start immediately, §IV-visible) |
+
+## Mutation & coverage audit (one-shot, 2026-06-29, #219)
+
+A measurement-first diagnostic (not a CI gate) to answer two questions the curated map above
+can't: (1) do the tests actually catch bugs or pass for-show, and (2) is any uncovered code an
+*accidental* gap. Tools: `coverage.py` (breadth — every module) + `cosmic-ray` mutation testing
+(depth — representative core modules). **No per-PR gate was added** (a coverage-% gate breeds
+for-show tests; see [#219](https://github.com/ekolvah/kinozal_scraper/issues/219) Out of scope).
+
+**Q1 — are the tests real? (mutation testing)**
+
+| Module | Mutants | Survived | Verdict |
+|---|---|---|---|
+| `pipeline_config.py` | 133 | 38 → **5** after filtering | 33 survivors are **equivalent mutants** (PEP-604 `\|` in *type annotations* — no runtime effect); 5 are genuine weaknesses → [#220](https://github.com/ekolvah/kinozal_scraper/issues/220) |
+| `text_utils.py` | 2 | 0 | indirect-only coverage is **real** |
+
+The 5 genuine `pipeline_config.py` survivors (most notable: `continue`→`break` at the field-CSS
+validation loop — CSS validation of `fields.*` is **not exercised when `dedupe_key` is absent**,
+a hole in the #57 feature) are tracked in [#220](https://github.com/ekolvah/kinozal_scraper/issues/220).
+
+**Q2 — is any uncovered code an accidental gap? (coverage.py)**
+
+No accidental gaps. Every uncovered region resolves to a *conscious* skip — the `__main__` CLI
+runners (scope-skip, live creds, cron-exercised) and `crypto.py` IO glue (cost-skip) — now
+documented in the table above. The audit's only Q2 action was documenting those two classes.
+
+**Method caveat (reusable):** raw mutation survival-% is misleading — PEP-604 union-type
+annotations (`X | None`) generate many `\|`-operator mutants with no runtime effect; filter them
+as equivalent *before* triaging. See [testing.md](testing.md#rule-reading-mutation-test-output).
+Reproduce: ephemeral `cosmic-ray` (mutmut refuses on Windows → WSL; cosmic-ray runs natively),
+`PYTHONUTF8=1` to avoid a cp1252-decode crash on non-ASCII test output, test-command pinned to the
+offline subset (`--ignore-glob=tests/test_e2e_*.py`).
 
 ## Test patterns
 

--- a/docs/architecture/test-coverage.md
+++ b/docs/architecture/test-coverage.md
@@ -37,41 +37,9 @@ row promoted to ✅.
 | Module | Reason | Mitigation |
 |---|---|---|
 | `youtube.py` | No Protocol boundary, requires live YouTube API | Indirect coverage via `test_kinozal_pipeline.py::TestEnrichWithTrailer` |
-| `text_utils.py` | Small utility | Indirect coverage via `test_kinozal_pipeline.py::TestTitleYearMatches` — **mutation-verified** (audit below: 0 survivors, the indirect coverage is real, not for-show) |
+| `text_utils.py` | Small utility | Indirect coverage via `test_kinozal_pipeline.py::TestTitleYearMatches` |
 | `*_pipeline.py` `if __name__ == "__main__"` blocks | CLI wiring of live `gspread`/env (`json`/`kinozal`/`events`/`github_trending`/`steam`) — needs live credentials | **Scope-skip**, exercised by the daily cron (§IV «cron = E2E smoke»): a wiring break → red CI / zero-row next run. The large uncovered blocks in the `coverage.py` map are these `__main__` runners, not logic gaps |
 | `crypto.py` (`crypto.save_/load_encrypter_session`) | File-IO glue (read/write `secret.key`/`anon.session*`) around the **tested** pure helpers `encrypt_bytes`/`decrypt_bytes` | **Cost-skip**: mocking the filesystem to guard trivial glue is negative-ROI; failure is loud (`KeyError`/`InvalidToken` crashes cron start immediately, §IV-visible) |
-
-## Mutation & coverage audit (one-shot, 2026-06-29, #219)
-
-A measurement-first diagnostic (not a CI gate) to answer two questions the curated map above
-can't: (1) do the tests actually catch bugs or pass for-show, and (2) is any uncovered code an
-*accidental* gap. Tools: `coverage.py` (breadth — every module) + `cosmic-ray` mutation testing
-(depth — representative core modules). **No per-PR gate was added** (a coverage-% gate breeds
-for-show tests; see [#219](https://github.com/ekolvah/kinozal_scraper/issues/219) Out of scope).
-
-**Q1 — are the tests real? (mutation testing)**
-
-| Module | Mutants | Survived | Verdict |
-|---|---|---|---|
-| `pipeline_config.py` | 133 | 38 → **5** after filtering | 33 survivors are **equivalent mutants** (PEP-604 `\|` in *type annotations* — no runtime effect); 5 are genuine weaknesses → [#220](https://github.com/ekolvah/kinozal_scraper/issues/220) |
-| `text_utils.py` | 2 | 0 | indirect-only coverage is **real** |
-
-The 5 genuine `pipeline_config.py` survivors (most notable: `continue`→`break` at the field-CSS
-validation loop — CSS validation of `fields.*` is **not exercised when `dedupe_key` is absent**,
-a hole in the #57 feature) are tracked in [#220](https://github.com/ekolvah/kinozal_scraper/issues/220).
-
-**Q2 — is any uncovered code an accidental gap? (coverage.py)**
-
-No accidental gaps. Every uncovered region resolves to a *conscious* skip — the `__main__` CLI
-runners (scope-skip, live creds, cron-exercised) and `crypto.py` IO glue (cost-skip) — now
-documented in the table above. The audit's only Q2 action was documenting those two classes.
-
-**Method caveat (reusable):** raw mutation survival-% is misleading — PEP-604 union-type
-annotations (`X | None`) generate many `\|`-operator mutants with no runtime effect; filter them
-as equivalent *before* triaging. See [testing.md](testing.md#rule-reading-mutation-test-output).
-Reproduce: ephemeral `cosmic-ray` (mutmut refuses on Windows → WSL; cosmic-ray runs natively),
-`PYTHONUTF8=1` to avoid a cp1252-decode crash on non-ASCII test output, test-command pinned to the
-offline subset (`--ignore-glob=tests/test_e2e_*.py`).
 
 ## Test patterns
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -111,6 +111,26 @@ trigger removal; a guard test asserting "no duplicate trigger" was added, then r
 work-for-work — the regression it guarded cost only CI minutes, not correctness. The
 forcing-function lives in [ci.md](ci.md) ("do not re-add `issue-*` to push") instead.
 
+## Rule: reading mutation-test output
+
+Mutation testing (a *survived* mutant = behaviour no test guards) is the only systematic way to
+catch a test that passed RED→GREEN but later rotted into a for-show test. It is a **one-shot
+diagnostic, never a per-PR CI gate** — a survival-% gate breeds for-show tests (the exact failure
+mode it's meant to find) and burns CI minutes (priority (2)). When you do run it:
+
+- **Filter equivalent mutants before triaging.** PEP-604 union-type annotations (`X | None`,
+  `str | Path`) are real expressions but their result is only `__annotations__` metadata — never
+  checked at runtime — so every `|`-operator mutant on them *survives* without being a gap. In the
+  2026-06-29 audit these were **33 of 38** raw `pipeline_config.py` survivors: the raw 28.6%
+  survival rate was misleading; the real figure after filtering was 5 (≈4%). Triage the operator,
+  not the count.
+- **Pin the test-command to the deterministic offline subset** (`--ignore-glob=tests/test_e2e_*.py`):
+  e2e-smoke / credential-gated tests flake → uninterpretable survivors.
+- **Tooling:** `mutmut` refuses on Windows (wants WSL); `cosmic-ray` runs natively. Run it from an
+  ephemeral venv (no `requirements*.in` edit — one-shot, not infra). Set `PYTHONUTF8=1` or
+  cosmic-ray crashes decoding non-ASCII (cp1252) test output. See the audit in
+  [test-coverage.md](test-coverage.md#mutation--coverage-audit-one-shot-2026-06-29-219).
+
 ## Rule: test behaviour, not implementation
 
 Test through the public entry point (`run_*_pipeline()`) and assert on observable **state**,

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -119,17 +119,15 @@ diagnostic, never a per-PR CI gate** — a survival-% gate breeds for-show tests
 mode it's meant to find) and burns CI minutes (priority (2)). When you do run it:
 
 - **Filter equivalent mutants before triaging.** PEP-604 union-type annotations (`X | None`,
-  `str | Path`) are real expressions but their result is only `__annotations__` metadata — never
-  checked at runtime — so every `|`-operator mutant on them *survives* without being a gap. In the
-  2026-06-29 audit these were **33 of 38** raw `pipeline_config.py` survivors: the raw 28.6%
-  survival rate was misleading; the real figure after filtering was 5 (≈4%). Triage the operator,
-  not the count.
+  `str | Path`) are real expressions whose result is only `__annotations__` metadata — never
+  checked at runtime — so every `|`-operator mutant on them *survives* without being a gap. They
+  typically dominate the raw survivor count, making the raw survival-% misleading. Triage the
+  operator, not the count.
 - **Pin the test-command to the deterministic offline subset** (`--ignore-glob=tests/test_e2e_*.py`):
   e2e-smoke / credential-gated tests flake → uninterpretable survivors.
 - **Tooling:** `mutmut` refuses on Windows (wants WSL); `cosmic-ray` runs natively. Run it from an
   ephemeral venv (no `requirements*.in` edit — one-shot, not infra). Set `PYTHONUTF8=1` or
-  cosmic-ray crashes decoding non-ASCII (cp1252) test output. See the audit in
-  [test-coverage.md](test-coverage.md#mutation--coverage-audit-one-shot-2026-06-29-219).
+  cosmic-ray crashes decoding non-ASCII (cp1252) test output.
 
 ## Rule: test behaviour, not implementation
 


### PR DESCRIPTION
Closes #219. Разовый measurement-аудит тест-сьюта (mutation + coverage), **docs-only** — продакшн-код не меняется.

## Что сделано
- **cosmic-ray** (mutmut не идёт на Windows → fallback на cosmic-ray, нативно, эфемерный venv — без правки `requirements*.in`) по `pipeline_config.py` и `text_utils.py` + **coverage.py** по всему `src/`.
- Детерминированный baseline (offline-subset, `--ignore-glob=tests/test_e2e_*.py`), `PYTHONUTF8=1` от cp1252-крэша cosmic-ray.

## Findings
**Q1 — тесты реальны?**
- `pipeline_config.py`: 38/133 выживших, но **33 — эквивалентные мутанты** (PEP-604 union-аннотации, нет рантайм-эффекта). Реальных слабых мест — **5** (главное: валидация CSS полей не прогоняется при отсутствии `dedupe_key` — дыра в #57) → follow-up #220.
- `text_utils.py`: 0/2 — косвенное покрытие реально, не для галочки.

**Q2 — случайные дыры?**
- Нет. Все непокрытые блоки = `__main__` CLI-обвязка (scope-skip, cron=E2E smoke) + `crypto.py` IO-glue (cost-skip). Оба класса раньше не были задокументированы — теперь учтены в coverage-map.

## Решения, вписанные в docs
- `test-coverage.md`: секция аудита + 2 новых класса осознанно-непокрытого.
- `testing.md`: правило «как читать вывод mutation-теста» (фильтровать эквивалентные мутанты; one-shot, не CI-гейт).

## Out of scope (осознанно)
- Никаких per-PR CI-гейтов (coverage-% / mutation) — рождает тесты для галочки.
- Фикс 5 мутантов → #220. cosmic-ray в `requirements` не добавлен (one-shot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
