### PR TITLE
feat(ci): ruff BLE001+TRY400 silence-detection gate (closes #231)

### DIFF
--- a/docs/architecture/principles.md
+++ b/docs/architecture/principles.md
@@ -99,6 +99,16 @@ technical alerts MUST NOT be collapsed into "no new items/messages."
 Forbidden: `try: ... except Exception: pass`, swallowing parse errors with
 default empty values, "fail open" branches that hide drift.
 
+Partly **machine-enforced** (not prose-only): ruff `BLE001` (no blind
+`except` swallow) and `TRY400` (`logger.exception`, not `logger.error`, inside
+handlers — preserve the traceback for §V) gate this in `ci_check`. A *deliberate*
+broad catch that is already visible (logs + surfaces the failure via
+`PipelineResult.errors` / a re-raise) opts out with an inline `# noqa: BLE001`
+carrying its rationale — keeping the exception a **consciously-decided** visible
+degradation, not a silent one. Config-level disabling (`select` removal or
+`ignore`/`per-file-ignores`) is itself blocked by
+`tests/test_ruff_silence_rules.py` ([#231](https://github.com/ekolvah/kinozal_scraper/issues/231)).
+
 **Rationale:** silent degradation is the worst kind of bug — users assume
 the system is working when it isn't, so nobody investigates. A visible gap
 or a red CI badge is a forcing function for someone to look.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ select = [
     "UP",
     "B",
     "SIM",
+    "BLE",
+    "TRY400",
 ]
 ignore = [
     "E501",

--- a/src/TelegramChannelSummarizer.py
+++ b/src/TelegramChannelSummarizer.py
@@ -137,7 +137,7 @@ class GeminiSummarizer:
                     failures.append(f"{model_name}: unavailable: {exc}")
                     logger.warning("model %s unavailable, trying next: %s", model_name, exc)
                     continue
-                logger.error("Error with model %s: %s", model_name, exc)
+                logger.error("Error with model %s: %s", model_name, exc)  # noqa: TRY400 — re-raised as SummarizationFailed with `from exc`; traceback surfaces upstream
                 raise SummarizationFailed("api_error", f"{model_name}: {exc}") from exc
 
         logger.error("all models exhausted, could not summarize")
@@ -234,8 +234,8 @@ class TelethonReader:
 
             result = "\n".join(formatted_messages)
             return channel_title, result, is_broadcast
-        except Exception as exc:
-            logger.error("Error processing channel %s: %s", channel_url, exc)
+        except Exception as exc:  # noqa: BLE001 — per-channel isolation: one channel error must not abort the run
+            logger.exception("Error processing channel %s: %s", channel_url, exc)
             return None, "", False
         finally:
             await client.disconnect()

--- a/src/events_pipeline.py
+++ b/src/events_pipeline.py
@@ -42,8 +42,8 @@ def run_events_pipeline(
         result = PipelineResult(source_id=source["id"])
         try:
             html_text = fetch_html(url)
-        except Exception as exc:
-            logger.error("[%s] fetch failed: %s", source["id"], exc)
+        except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+            logger.exception("[%s] fetch failed: %s", source["id"], exc)
             result.errors.append(f"fetch failed: {exc}")
             results.append(result)
             continue

--- a/src/gemini_enricher.py
+++ b/src/gemini_enricher.py
@@ -239,8 +239,8 @@ def get_generation_models() -> list[str]:
             and _is_text_gemini(m.name)
             and m.name not in _EXCLUDED_MODELS
         ]
-    except Exception:
-        logger.warning("cannot list models")
+    except Exception:  # noqa: BLE001 — list-models failure degrades to []; now visible via logger.exception (not silent)
+        logger.exception("cannot list models")
         return []
 
     names.sort(key=_model_version_key, reverse=True)

--- a/src/github_trending_pipeline.py
+++ b/src/github_trending_pipeline.py
@@ -111,8 +111,8 @@ def run_github_trending_pipeline(
         result = PipelineResult(source_id=source["id"])
         try:
             html_text = fetch_html(url)
-        except Exception as exc:
-            logger.error("[%s] fetch failed: %s", source["id"], exc)
+        except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+            logger.exception("[%s] fetch failed: %s", source["id"], exc)
             result.errors.append(f"fetch failed: {exc}")
             results.append(result)
             continue

--- a/src/json_pipeline.py
+++ b/src/json_pipeline.py
@@ -58,8 +58,8 @@ def run_json_pipeline(
     for source in json_sources:
         try:
             result = _run_single_source(source, storage, notifier, enricher)
-        except Exception as exc:
-            logger.error("[%s] unhandled error: %s", source["id"], exc)
+        except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+            logger.exception("[%s] unhandled error: %s", source["id"], exc)
             result = PipelineResult(source_id=source["id"])
             result.errors.append(f"unhandled error: {exc}")
         results.append(result)
@@ -82,8 +82,8 @@ def _run_single_source(
             source.get("params", {}),
             source.get("headers", {}),
         )
-    except Exception as exc:
-        logger.error("[%s] fetch failed: %s", source_id, exc)
+    except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+        logger.exception("[%s] fetch failed: %s", source_id, exc)
         result.errors.append(f"fetch failed: {exc}")
         return result
 

--- a/src/kinozal_pipeline.py
+++ b/src/kinozal_pipeline.py
@@ -69,7 +69,7 @@ class _KinozalFetcher:
     def fetch(self, url: str) -> str:
         try:
             return fetch_html(url)
-        except Exception as primary_exc:
+        except Exception as primary_exc:  # noqa: BLE001 — any primary-fetch failure falls back to the mirror
             return self._from_mirror(url, primary_exc)
 
     def _from_mirror(self, url: str, primary_exc: Exception) -> str:
@@ -105,7 +105,7 @@ class _KinozalFetcher:
             # holds — otherwise every subsequent URL retries a dead login,
             # costing N×timeout seconds.
             self._login_error = str(exc)
-            logger.error("kinozal mirror login failed: %s", exc)
+            logger.error("kinozal mirror login failed: %s", exc)  # noqa: TRY400 — re-raised as RuntimeError with `from exc`; traceback surfaces at the isolation boundary
             raise RuntimeError(f"mirror login failed: {exc}") from exc
         return self._session
 
@@ -177,8 +177,8 @@ def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
         year_match = re.search(r"\b(20\d{2})\b", raw_for_year)
         year = int(year_match.group(1)) if year_match else None
         return youtube.get_trailer_url(clean, year=year) or ""
-    except Exception as exc:
-        logger.error("trailer lookup failed for %r: %s", item.title, exc)
+    except Exception as exc:  # noqa: BLE001 — trailer lookup degrades to no-trailer, item still notified
+        logger.exception("trailer lookup failed for %r: %s", item.title, exc)
         return ""
 
 
@@ -233,8 +233,8 @@ def run_kinozal_pipeline(
         for url in urls:
             try:
                 html_text = fetcher.fetch(url)
-            except Exception as exc:
-                logger.error("[%s] fetch failed for %s: %s", source["id"], url, exc)
+            except Exception as exc:  # noqa: BLE001 — per-URL isolation: logged + surfaced via result.errors
+                logger.exception("[%s] fetch failed for %s: %s", source["id"], url, exc)
                 result.errors.append(f"fetch failed for {url}: {exc}")
                 continue
             extracted = _extract_kinozal_items(html_text, source)

--- a/src/steam_pipeline.py
+++ b/src/steam_pipeline.py
@@ -72,7 +72,7 @@ def _resolve_name(appid: int, source_id: str) -> tuple[str, str]:
     """
     try:
         details = _fetch_appdetails(appid)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 — appdetails failure degrades to None, item still notified
         logger.warning("[%s] appdetails fetch failed for %s: %s", source_id, appid, exc)
         details = None
     if details and details.get("name"):
@@ -189,8 +189,8 @@ def run_steam_pipeline(
     for source in steam_sources:
         try:
             result = _run_single_source(source, storage, notifier, enricher)
-        except Exception as exc:
-            logger.error("[%s] unhandled error: %s", source["id"], exc)
+        except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+            logger.exception("[%s] unhandled error: %s", source["id"], exc)
             result = PipelineResult(source_id=source["id"])
             result.errors.append(f"unhandled error: {exc}")
         results.append(result)
@@ -214,8 +214,8 @@ def _run_single_source(
     # 1. Fetch the Most Played charts payload.
     try:
         data = _fetch_charts(url)
-    except Exception as exc:
-        logger.error("[%s] charts fetch failed: %s", source_id, exc)
+    except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+        logger.exception("[%s] charts fetch failed: %s", source_id, exc)
         result.errors.append(f"charts fetch failed: {exc}")
         return result
 

--- a/src/telegram_summarizer.py
+++ b/src/telegram_summarizer.py
@@ -92,8 +92,8 @@ def deliver_results(notifier: Any, results: list[ChannelProcessResult]) -> int:
         if send_required_text(notifier, format_technical_alert(results)):
             try:
                 mark_technical_alert_sent()
-            except Exception as exc:
-                logger.error("Could not write technical alert marker: %s", exc)
+            except Exception as exc:  # noqa: BLE001 — marker write failure must not crash the alert path
+                logger.exception("Could not write technical alert marker: %s", exc)
         return 1
 
     return 0

--- a/tests/test_ruff_silence_rules.py
+++ b/tests/test_ruff_silence_rules.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 _REPO = Path(__file__).resolve().parents[1]
 _PYPROJECT = _REPO / "pyproject.toml"
@@ -27,7 +27,7 @@ _DISABLE_TOKENS = {"BLE", "BLE001", "TRY400"}
 
 def _lint_config() -> dict[str, Any]:
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
-    return data["tool"]["ruff"]["lint"]
+    return cast("dict[str, Any]", data["tool"]["ruff"]["lint"])
 
 
 class TestRuffSilenceRules:
@@ -37,7 +37,7 @@ class TestRuffSilenceRules:
         # (a) present in effective select (select ∪ extend-select) — robust to
         # a future move to extend-select (architect NICE #6).
         selected = set(lint.get("select", [])) | set(lint.get("extend-select", []))
-        assert _SILENCE_CODES <= selected, (
+        assert selected >= _SILENCE_CODES, (
             "silence-detection codes must be in ruff select (§IV/§V gate); "
             f"missing: {_SILENCE_CODES - selected}"
         )

--- a/tests/test_ruff_silence_rules.py
+++ b/tests/test_ruff_silence_rules.py
@@ -1,0 +1,62 @@
+"""Anti-drift guard for the §IV/§V silence-detection ruff rules (#231).
+
+§IV (visibility over silence) and §V (root cause before fix) are partly
+machine-enforced via ruff `BLE001` (no blind `except`) and `TRY400`
+(`logger.exception` in handlers — preserve the traceback). This guard asserts
+those codes stay *active*: present in the effective select AND not silently
+neutralised via `ignore` / `per-file-ignores`. Mirrors `test_settings_deny.py`
+— it pins *enforcement*, not mere declaration, so a future agent cannot quietly
+drop the gate through any of the disable vectors (#231 BLOCKING #1).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any
+
+_REPO = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO / "pyproject.toml"
+
+# Codes that must be selected. Prefix forms are how ruff config carries them.
+_SILENCE_CODES = {"BLE", "TRY400"}
+# Any of these tokens, if present in ignore / per-file-ignores, disables a
+# silence rule while leaving `select` untouched — the threat-model of #231.
+_DISABLE_TOKENS = {"BLE", "BLE001", "TRY400"}
+
+
+def _lint_config() -> dict[str, Any]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return data["tool"]["ruff"]["lint"]
+
+
+class TestRuffSilenceRules:
+    def test_silence_rules_active(self) -> None:
+        lint = _lint_config()
+
+        # (a) present in effective select (select ∪ extend-select) — robust to
+        # a future move to extend-select (architect NICE #6).
+        selected = set(lint.get("select", [])) | set(lint.get("extend-select", []))
+        assert _SILENCE_CODES <= selected, (
+            "silence-detection codes must be in ruff select (§IV/§V gate); "
+            f"missing: {_SILENCE_CODES - selected}"
+        )
+
+        # (b) not neutralised via ignore (BLOCKING #1 disable vector).
+        ignored = set(lint.get("ignore", []))
+        assert not (_DISABLE_TOKENS & ignored), (
+            "silence-detection codes must not appear in ruff `ignore` (silently "
+            f"disables the §IV gate): {_DISABLE_TOKENS & ignored}"
+        )
+
+        # (c) not neutralised via per-file-ignores (BLOCKING #1 disable vector).
+        per_file = lint.get("per-file-ignores", {})
+        leaked = {
+            path: sorted(_DISABLE_TOKENS & set(codes))
+            for path, codes in per_file.items()
+            if _DISABLE_TOKENS & set(codes)
+        }
+        assert not leaked, (
+            "silence-detection codes must not appear in `per-file-ignores` "
+            f"(silently disables the §IV gate): {leaked}"
+        )

--- a/tests/test_ruff_silence_rules.py
+++ b/tests/test_ruff_silence_rules.py
@@ -22,7 +22,7 @@ _PYPROJECT = _REPO / "pyproject.toml"
 _SILENCE_CODES = {"BLE", "TRY400"}
 # Any of these tokens, if present in ignore / per-file-ignores, disables a
 # silence rule while leaving `select` untouched — the threat-model of #231.
-_DISABLE_TOKENS = {"BLE", "BLE001", "TRY400"}
+_DISABLE_TOKENS = {"BLE", "BLE001", "TRY", "TRY400"}
 
 
 def _lint_config() -> dict[str, Any]:


### PR DESCRIPTION
## Что и зачем

§IV (видимость > молчания) и §V (root cause) держались на прозе + architect-review. Теперь **частично machine-enforced** через ruff: добавлены `BLE001` (no blind-except swallow) и `TRY400` (`logger.exception`, не `logger.error`, в хендлерах — сохранение трейсбека) в `select` `pyproject.toml`. Едет на существующем `ci_check::check_lint`, без нового гейта/зависимости.

Closes #231.

## Изменения

- **config**: `pyproject.toml` select += `BLE`, `TRY400`.
- **12 TRY400** → `logger.error`→`logger.exception` (swallow-сайты); **2 re-raise сайта** (`from exc`: kinozal mirror-login, SummarizationFailed) → inline `# noqa: TRY400` с обоснованием (трейсбек уже в цепочке, surface upstream — двойной лог не нужен).
- **13 BLE001** → inline `# noqa: BLE001` + rationale. Широкие `except Exception` в пайплайнах — **сознательные isolation-границы**, уже §IV-visible (logged + surfaced via `PipelineResult.errors` + continue; есть `test_fetch_failure_isolated_*`). Гейт ловит **новые** непрозрачные catch, а не имитирует чистку текущих.
- **`gemini_enricher` list-models** (architect SHOULD-FIX #3): `logger.warning`→`logger.exception` — пустой `[]` теперь видимая деградация, не silent fail-open.
- **Guard `tests/test_ruff_silence_rules.py`**: config-invariant анти-дрейф — падает, если коды убраны из `select` ИЛИ добавлены в `ignore`/`per-file-ignores` (оба disable-вектора, architect BLOCKING #1). Зеркало `test_settings_deny.py`.

## RED→GREEN
- RED: `test: failing tests for #231` (guard падает — коды не в select).
- GREEN: config + 25 сайтов + docs. `ci_check` зелёный (427 passed, 3 skipped).

## Docs
- `principles.md §IV` — пометка о machine-enforcement + escape через inline noqa с rationale.
- **Отклонение от плана**: guard НЕ внесён в bug-class таблицу `test-coverage.md` (A–J) — это governance-guard, не ловец рантайм-бага; прецедент `test_settings_deny.py` там тоже отсутствует (консистентность).

## Out of scope (отдельные issue)
ERA001 (dead-code, FP-prone), complexity-метрики (C90/PLR), import-linter (§II), ARG/SLF001 триаж.

## Note
Поведенческий контракт пайплайнов не меняется; меняется лог-формат (богаче — трейсбек).

🤖 Generated with [Claude Code](https://claude.com/claude-code)