### PR TITLE
fix(workflow): прокинуть GOOGLE_API_KEY в steam-шаг — оживить перевод описаний (closes #239)

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -56,6 +56,9 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.BOT_CHATID }}
           CREDENTIALS: ${{ secrets.CREDENTIALS }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
+          GEMINI_EXCLUDED_MODELS: ${{ vars.GEMINI_EXCLUDED_MODELS }}
 
       - name: Run events pipeline
         run: python -m kinozal_scraper.events_pipeline


### PR DESCRIPTION
## Summary

Шаг `Run Steam charts pipeline` в `run-script.yml` не прокидывал `GOOGLE_API_KEY` (+ `LLM_MODEL`, `GEMINI_EXCLUDED_MODELS`) в свой `env:`. В GitHub Actions переменные видны только тому шагу, где явно перечислены → `build_default_enricher` получал пустой ключ → `NullEnricher` → §IV-фолбэк подставлял **английское** `short_description` в `{description_ru}`. Перевод описаний Steam-игр (#124) был **мёртв в проде с момента релиза** — уведомления уходили целиком, но без русского перевода (в логах `WARNING ... enrichment disabled` каждый прогон).

Не связано с миграцией #237/#238 — всплыло при чтении её логов.

## Fix

Добавлены три env-переменные в steam-шаг по образцу json/github_trending-шагов (per-step, в русле принятого least-privilege-паттерна файла — без выноса на job-level). Тот же существующий секрет/механизм, просто проводка в этот шаг.

## Test plan

Workflow-config-only, поведенческого кода нет → unit-тест не пишется (нет автотеста на проводку Actions-env; контракт `_apply_translation` уже покрыт `test_steam_pipeline.py`). `ci_check.py` зелёный (pre-push). **Верификация после мержа:** ручной `workflow_dispatch` — в логах steam-шага вместо `enrichment disabled` ожидается `[steam_charts_mostplayed] translated N/M items`, `{description_ru}` в уведомлении — на русском.

## Out of scope

Рефактор общих секретов на job-level `env:` (убрать дублирование env-блоков по шагам) — отдельная стилистическая задача про весь workflow, меняет least-privilege-модель и затрагивает все шаги.

closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
