### PR TITLE
fix(ci): изолировать пайплайн-шаги run-script.yml (closes #245)

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -21,9 +21,15 @@ jobs:
           pip install -e . --no-deps  # entry points run as `python -m kinozal_scraper.X`
 
       - name: Run pure logic tests
+        id: tests
         run: python -m pytest tests/ -x
 
       - name: Run JSON sources pipeline
+        # Isolated from siblings (#245): !cancelled() lets this run even if an
+        # earlier pipeline step failed (the implicit if: success() would skip it),
+        # while gating on the test step keeps red tests a hard block. No
+        # continue-on-error: a failed source must red the job so the §IV alert fires.
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' }}
         run: python -m kinozal_scraper.json_pipeline
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,6 +43,7 @@ jobs:
           GEMINI_EXCLUDED_MODELS: ${{ vars.GEMINI_EXCLUDED_MODELS }}
 
       - name: Run GitHub trending pipeline
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' }}
         run: python -m kinozal_scraper.github_trending_pipeline
         env:
           GH_TRENDING_LIMIT: ${{ vars.GH_TRENDING_LIMIT || '10' }}
@@ -49,6 +56,7 @@ jobs:
           GEMINI_EXCLUDED_MODELS: ${{ vars.GEMINI_EXCLUDED_MODELS }}
 
       - name: Run Steam charts pipeline
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' }}
         run: python -m kinozal_scraper.steam_pipeline
         env:
           STEAM_TOP_LIMIT: ${{ vars.STEAM_TOP_LIMIT }}
@@ -61,6 +69,7 @@ jobs:
           GEMINI_EXCLUDED_MODELS: ${{ vars.GEMINI_EXCLUDED_MODELS }}
 
       - name: Run events pipeline
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' }}
         run: python -m kinozal_scraper.events_pipeline
         env:
           SOLDOUT_URL: ${{ vars.SOLDOUT_URL }}
@@ -70,6 +79,7 @@ jobs:
           CREDENTIALS: ${{ secrets.CREDENTIALS }}
 
       - name: Run Kinozal pipeline
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' }}
         run: python -m kinozal_scraper.kinozal_pipeline
         env:
           CREDENTIALS: ${{ secrets.CREDENTIALS }}

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -97,14 +97,42 @@ No separate Anthropic API billing — usage counts against the Pro/Max subscript
 
 Schedule: daily cron (UTC) defined in `run-script.yml` + manual `workflow_dispatch`.
 
-Steps run sequentially:
-1. **pytest** — smoke gate, fails fast
+Steps, in order:
+1. **pytest** — smoke gate (`id: tests`), fails fast; a red gate blocks every prod pipeline below
 2. **json_pipeline.py** — GitHub `new_popular`
 3. **github_trending_pipeline.py** — GitHub trending (HTML + enrichment)
 4. **steam_pipeline.py** — Steam Most Played (Steam Charts API + appdetails)
 5. **events_pipeline.py** — Soldout events
 6. **kinozal_pipeline.py** — Kinozal movies
 7. **telegram_summarizer.py** — `if: always()` (runs even if earlier steps fail)
+
+### Pipeline-step isolation (#245)
+
+**Root cause it fixes:** GitHub Actions steps carry an *implicit* `if: success()`. So a
+single step's `exit 1` used to cascade into **skipping every later step** — a transient
+third-party 403 in `events_pipeline` skipped `kinozal_pipeline` and suppressed movie
+delivery for that run ([run 28493805028](https://github.com/ekolvah/kinozal_scraper/actions/runs/28493805028)).
+Per-source isolation existed *inside* each `run_*_pipeline`, but not *between* the workflow
+steps.
+
+**Fix:** each pipeline step (2–6) carries
+`if: ${{ !cancelled() && steps.tests.outcome == 'success' }}`:
+
+- `!cancelled()` — the step runs even if an **earlier pipeline** step failed (defeats the
+  implicit `if: success()` cascade), so a flaky source can't suppress an unrelated one.
+- `steps.tests.outcome == 'success'` — but a **red smoke gate still skips every pipeline**
+  (the hard prerequisite is preserved; that's why the gate carries `id: tests`).
+- **No `continue-on-error`** — a failed source still exits 1 → job goes red → the existing
+  `Send fallback failure alert` (`if: failure()`) fires. Failure stays visible (§IV); it is
+  *not* masked into a green job. This is why a `continue-on-error` + aggregate-gate design
+  was rejected: it masks `conclusion` and adds a moving part.
+
+`telegram_summarizer` (step 7) is deliberately **not** isolated — it keeps `if: always()`
+and no `continue-on-error`, so its own failure hard-fails the job (§IV). The invariant is
+guarded statically by `tests/test_workflow_isolation.py::TestPipelineStepIsolation`, which
+*derives* the pipeline set from the workflow (any step running `kinozal_scraper.*_pipeline`)
+so a newly-added source is automatically held to it — a hand-maintained list would let the
+next source slip back into the cascade.
 
 ## Environment variables
 

--- a/tests/test_workflow_isolation.py
+++ b/tests/test_workflow_isolation.py
@@ -1,0 +1,87 @@
+"""Guard: pipeline steps in run-script.yml are isolated from each other (#245).
+
+A transient failure of one source (e.g. a third-party 403 on soldout) must not
+skip the other pipeline steps in the same scheduled run. GitHub Actions steps run
+with an *implicit* `if: success()`, so one step's `exit 1` cascades into skipping
+every later step — which is how a soldout flap suppressed kinozal delivery in run
+28493805028. The fix isolates each pipeline step via
+`if: ${{ !cancelled() && steps.<gate>.outcome == 'success' }}` (isolation from
+siblings + hard test gate) while keeping the natural `exit 1` (no continue-on-error)
+so a failed source still reds the job and fires the §IV fallback alert.
+
+These are static YAML guards (no network/credentials), like `test_repo_layout.py`.
+The pipeline set is *derived* from the workflow (every step whose `run` invokes a
+`kinozal_scraper.*_pipeline` module), so a newly-added source is automatically held
+to the invariant instead of slipping through a hand-maintained list.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "run-script.yml"
+# A pipeline step is one that runs `python -m kinozal_scraper.<name>_pipeline`.
+# telegram_summarizer (not *_pipeline) and the pytest gate are intentionally excluded.
+_PIPELINE_RUN = re.compile(r"python -m kinozal_scraper\.\w+_pipeline")
+
+
+def _steps() -> list[dict[str, Any]]:
+    data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    return data["jobs"]["run-script"]["steps"]
+
+
+def _pipeline_steps() -> list[dict[str, Any]]:
+    return [s for s in _steps() if _PIPELINE_RUN.search(str(s.get("run", "")))]
+
+
+def _gate_step() -> dict[str, Any]:
+    gates = [s for s in _steps() if "pytest" in str(s.get("run", ""))]
+    assert len(gates) == 1, f"expected exactly one pytest gate step, got {len(gates)}"
+    return gates[0]
+
+
+def _norm(expr: str) -> str:
+    """Collapse whitespace so `steps.tests.outcome == 'success'` matches regardless
+    of spacing / `${{ }}` wrapping."""
+    return re.sub(r"\s+", "", expr)
+
+
+class TestPipelineStepIsolation:
+    def test_every_pipeline_step_isolated_without_masking(self) -> None:
+        pipelines = _pipeline_steps()
+        assert len(pipelines) >= 5, (
+            f"derived {len(pipelines)} pipeline steps, expected >=5 "
+            "(json/github_trending/steam/events/kinozal)"
+        )
+        gate_id = _gate_step().get("id")
+        assert gate_id, "pytest gate step needs an `id` so pipeline steps can gate on its outcome"
+        for step in pipelines:
+            name = step.get("name", step.get("run"))
+            cond = _norm(str(step.get("if", "")))
+            assert "!cancelled()" in cond, (
+                f"pipeline step {name!r} must run under !cancelled() so a sibling's "
+                f"failure doesn't skip it (implicit if: success() cascades) — got if={step.get('if')!r}"
+            )
+            assert f"steps.{gate_id}.outcome=='success'" in cond, (
+                f"pipeline step {name!r} must gate on the test step "
+                f"(steps.{gate_id}.outcome == 'success') — got if={step.get('if')!r}"
+            )
+            assert step.get("continue-on-error") is not True, (
+                f"pipeline step {name!r} must NOT set continue-on-error: a failed source "
+                "must red the job so the §IV fallback alert fires, not be masked green"
+            )
+
+    def test_pure_logic_test_gate_is_hard_prerequisite(self) -> None:
+        gate = _gate_step()
+        assert gate.get("id"), "pytest gate step must have an `id`"
+        assert "if" not in gate, (
+            "pytest gate must run unconditionally (no isolation `if`) — it is the hard "
+            "prerequisite; pipelines gate on ITS outcome, not the reverse"
+        )
+        assert gate.get("continue-on-error") is not True, (
+            "pytest gate must not set continue-on-error — red tests must block prod pipelines"
+        )

--- a/tests/test_workflow_isolation.py
+++ b/tests/test_workflow_isolation.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -31,7 +31,7 @@ _PIPELINE_RUN = re.compile(r"python -m kinozal_scraper\.\w+_pipeline")
 
 def _steps() -> list[dict[str, Any]]:
     data = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
-    return data["jobs"]["run-script"]["steps"]
+    return cast("list[dict[str, Any]]", data["jobs"]["run-script"]["steps"])
 
 
 def _pipeline_steps() -> list[dict[str, Any]]:


### PR DESCRIPTION
Closes #245.

## Проблема

Scheduled-прогон [28493805028](https://github.com/ekolvah/kinozal_scraper/actions/runs/28493805028) упал: транзиентный `HTTP Error 403` от стороннего `soldoutticketbox.com` в шаге `Run events pipeline`. Шаги GHA несут **неявный `if: success()`**, поэтому `exit 1` одного шага каскадно **скипнул** `Run Kinozal pipeline` — флап второстепенного источника подавил доставку основного (kinozal). Per-source изоляция была только *внутри* пайплайнов, не *между* шагами workflow.

## Фикс

Каждому из 5 пайплайн-шагов добавлен `if: ${{ !cancelled() && steps.tests.outcome == 'success' }}`:
- **`!cancelled()`** — сиблинг бежит, даже если предыдущий пайплайн упал → каскад снят.
- **`steps.tests.outcome == 'success'`** — красный smoke-gate по-прежнему скипает все прод-пайплайны (жёсткий prerequisite сохранён; gate получил `id: tests`).
- **без `continue-on-error`** — упавший источник натурально `exit 1` → job red → существующий `Send fallback failure alert` (`if: failure()`) срабатывает. Падение видимо (§IV), не маскируется в зелёный job.

`Run Telegram summarizer` намеренно **не** изолирован — остаётся `if: always()` + жёсткий (его провал должен доходить).

## Почему так, а не aggregate

`continue-on-error` + финальный aggregate-шаг тоже работает, но маскирует `conclusion` (§IV-рассуждение косвенное) и добавляет движущуюся часть с набором пайплайнов, который пришлось бы хардкодить. Выбран более простой механизм (architect-review п.4).

## Тест

`tests/test_workflow_isolation.py::TestPipelineStepIsolation` — статический YAML-guard (без сети/креденшелов, как `test_repo_layout.py`). Набор пайплайнов **деривится** из workflow (любой шаг с `run: python -m kinozal_scraper.*_pipeline`), поэтому новый источник автоматически под инвариантом — hand-maintained список дал бы следующему источнику проскользнуть обратно в каскад. TDD: RED (2 failed) → GREEN.

## Проверка

`ci_check.py` зелёный: 458 passed, 3 skipped (e2e #136).

🤖 Generated with [Claude Code](https://claude.com/claude-code)