### PR TITLE
feat(kinozal): ссылки в уведомлениях следуют за origin листинга (closes #247)

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -191,7 +191,7 @@ next source slip back into the cascade.
 > **Включение fallback:** задай оба секрета `KINOZAL_USERNAME` + `KINOZAL_PASSWORD`. Без них (или при
 > partial) fallback отключён, и сбой `.tv` доходит видимой ошибкой `fetch failed ... (mirror
 > fallback disabled)` + exit 1 (§IV) — как было до #227. Провал логина / both-failed тоже видимы:
-> `mirror login failed` / `primary failed (...); mirror ... also failed (...)`. `sources.json`
+> `mirror login failed` / `primary failed (...); mirror ... also failed (...)`.
 > `sources.json` `base_url` остаётся `https://kinozal.tv` (дефолтный origin, когда primary жив) —
 > зеркало туда не прописывать.
 >

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -192,8 +192,18 @@ next source slip back into the cascade.
 > partial) fallback отключён, и сбой `.tv` доходит видимой ошибкой `fetch failed ... (mirror
 > fallback disabled)` + exit 1 (§IV) — как было до #227. Провал логина / both-failed тоже видимы:
 > `mirror login failed` / `primary failed (...); mirror ... also failed (...)`. `sources.json`
-> `base_url` остаётся `https://kinozal.tv` (canonical origin для ссылок в уведомлениях) — зеркало в
-> `sources.json` не прописывать.
+> `sources.json` `base_url` остаётся `https://kinozal.tv` (дефолтный origin, когда primary жив) —
+> зеркало туда не прописывать.
+>
+> **Ссылки следуют за фактическим origin (#247):** `Kinozal.fetch_listing` возвращает
+> `(html, effective_base_url)` — `kinozal.tv` при успехе primary, `kinozal.guru` при mirror-fallback.
+> Пайплайн резолвит относительные `url`/`image_url` листинга против этого базового хоста (per-fetch
+> override статичного `base_url`), поэтому mirror-прогон даёт **`.guru`-ссылки** — живые для
+> залогиненного получателя, а не мёртвые `.tv`. Это осознанный разворот исходного #227/#241 решения
+> «`base_url` всегда `.tv` — canonical origin для ссылок» (основание: получатель залогинен на `.guru`,
+> login-wall для него неактуален). Смешанный прогон (часть топов с `.tv`, часть с зеркала) даёт
+> корректный хост у каждого item; dedupe стабилен (ключ — чистый title, host в него не входит →
+> миграция старых `.tv`-строк в Sheet не нужна).
 >
 > Сейчас потребитель — production-cron (`run-script.yml` / `kinozal_pipeline.py`). E2E
 > `tests/test_e2e_kinozal_titles.py` станет вторым потребителем после #136 (тест безусловно

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -51,6 +51,14 @@ def _mirror_url(url: str) -> str:
     return urlunsplit(urlsplit(url)._replace(netloc=_MIRROR_HOST))
 
 
+def _origin(url: str) -> str:
+    """scheme://host of a URL — the base against which relative links/posters in
+    that listing must resolve (#247). Derived from the URL actually fetched, so
+    it follows origin→mirror failover instead of a hardcoded canonical host."""
+    parts = urlsplit(url)
+    return f"{parts.scheme}://{parts.netloc}"
+
+
 class Kinozal:
     """Facade for all kinozal IO: anonymous kinozal.tv primary with a lazy
     kinozal.guru mirror fallback. One object owns the origin-vs-mirror decision
@@ -88,11 +96,17 @@ class Kinozal:
             )
         return cls(username, password)
 
-    def fetch_listing(self, url: str) -> str:
+    def fetch_listing(self, url: str) -> tuple[str, str]:
+        """Return (html, effective_base_url): the HTML plus the origin that
+        actually served it (#247). Primary success → the requested origin
+        (kinozal.tv); mirror fallback → kinozal.guru. The pipeline resolves the
+        listing's relative links/posters against this base, so a mirror-served
+        page yields .guru links (live for the logged-in user) instead of dead
+        .tv ones — reversing #227/#241's fixed canonical-origin choice."""
         try:
-            return fetch_html(url)
+            return fetch_html(url), _origin(url)
         except Exception as primary_exc:  # noqa: BLE001 — any primary-fetch failure falls back to the mirror
-            return self._from_mirror(url, primary_exc)
+            return self._from_mirror(url, primary_exc), _origin(_mirror_url(url))
 
     def fetch_poster(self, url: str) -> bytes:
         """Download a poster, sharing the listing's origin→mirror failover (#241).
@@ -173,8 +187,16 @@ def _kinozal_title(raw: str) -> str:
     return raw.split(" / ")[0].strip()
 
 
-def _extract_kinozal_items(html: str, source: dict[str, Any]) -> PipelineResult:
+def _extract_kinozal_items(
+    html: str, source: dict[str, Any], base_url: str | None = None
+) -> PipelineResult:
     """Parse kinozal HTML and return PipelineResult with clean titles and raw dedupe_keys.
+
+    `base_url`, when given, overrides `source["base_url"]` for this one fetch so
+    relative links AND posters resolve against the host that actually served the
+    HTML (#247). `extract_from_html` resolves both `url` and `image_url` through
+    the same base, so mirror-served posters follow to .guru for free. The source
+    dict is shallow-copied, never mutated (it is shared across the run).
 
     Returns the underlying `extract_from_html` result (errors included) so the
     runner can propagate failures to its own PipelineResult. Earlier revision
@@ -186,6 +208,8 @@ def _extract_kinozal_items(html: str, source: dict[str, Any]) -> PipelineResult:
     dropping them would just look like "no new films" to the user. The WARNING
     is the dev-side tripwire for the same situation in logs.
     """
+    if base_url is not None:
+        source = {**source, "base_url": base_url}
     result = extract_from_html(html, source)
     if not result.ok:
         logger.error("[%s] extraction errors: %s", source["id"], result.errors)
@@ -290,12 +314,14 @@ def run_kinozal_pipeline(
         result = PipelineResult(source_id=source["id"])
         for url in urls:
             try:
-                html_text = fetcher.fetch_listing(url)
+                html_text, effective_base_url = fetcher.fetch_listing(url)
             except Exception as exc:  # noqa: BLE001 — per-URL isolation: logged + surfaced via result.errors
                 logger.exception("[%s] fetch failed for %s: %s", source["id"], url, exc)
                 result.errors.append(f"fetch failed for {url}: {exc}")
                 continue
-            extracted = _extract_kinozal_items(html_text, source)
+            # Resolve this listing's links/posters against the origin that served
+            # it (.tv on primary, .guru on mirror fallback) — not a fixed host (#247).
+            extracted = _extract_kinozal_items(html_text, source, base_url=effective_base_url)
             if not extracted.ok:
                 result.errors.extend(extracted.errors)
                 continue

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -396,7 +396,9 @@ class TestPipelineNotificationContent(unittest.TestCase):
         storage, notifier = _run()
         text = notifier.sent[0].text
         self.assertIn("<b>", text)
-        self.assertIn("kinozal.tv/details.php", text)
+        # Link host follows the origin that served the listing (#247); _run mocks
+        # the fetch at https://test.example, so the resolved link does too.
+        self.assertIn("test.example/details.php", text)
 
     def test_trailer_included_when_present(self) -> None:
         storage, notifier = _run()
@@ -973,9 +975,7 @@ class TestFetchListingOrigin(unittest.TestCase):
                 "kinozal_scraper.kinozal_pipeline.fetch_html",
                 side_effect=RuntimeError("HTTP Error 522"),
             ),
-            unittest.mock.patch(
-                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
-            ),
+            unittest.mock.patch("kinozal_scraper.kinozal_pipeline.login", return_value=sentinel),
             unittest.mock.patch(
                 "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_KINOZAL_HTML
             ),
@@ -1007,9 +1007,7 @@ class TestLinkOriginFollowsHost(unittest.TestCase):
                 "kinozal_scraper.kinozal_pipeline.fetch_html",
                 side_effect=RuntimeError("HTTP Error 522"),
             ),
-            unittest.mock.patch(
-                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
-            ),
+            unittest.mock.patch("kinozal_scraper.kinozal_pipeline.login", return_value=sentinel),
             unittest.mock.patch(
                 "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_KINOZAL_HTML
             ),
@@ -1026,9 +1024,7 @@ class TestLinkOriginFollowsHost(unittest.TestCase):
                 "kinozal_scraper.kinozal_pipeline.fetch_html",
                 side_effect=RuntimeError("HTTP Error 522"),
             ),
-            unittest.mock.patch(
-                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
-            ),
+            unittest.mock.patch("kinozal_scraper.kinozal_pipeline.login", return_value=sentinel),
             unittest.mock.patch(
                 "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_KINOZAL_HTML
             ),
@@ -1049,9 +1045,7 @@ class TestLinkOriginFollowsHost(unittest.TestCase):
             unittest.mock.patch(
                 "kinozal_scraper.kinozal_pipeline.fetch_html", side_effect=_fake_fetch
             ),
-            unittest.mock.patch(
-                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
-            ),
+            unittest.mock.patch("kinozal_scraper.kinozal_pipeline.login", return_value=sentinel),
             unittest.mock.patch(
                 "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_HTML_B
             ),

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -935,5 +935,135 @@ class TestNotifierWiring(unittest.TestCase):
         self.assertEqual(data, b"MIRROR")  # poster reached via mirror, not dropped
 
 
+# ── link origin follows the serving host (issue #247) ─────────────────────────
+
+# Distinct-title fixtures for the mixed-origin run: same-title collapse would
+# make "which host won" ambiguous, so each URL yields its own title.
+_HTML_A = (
+    '<html><body><a href="/details.php?id=1" title="Alpha Film / 2024">'
+    '<img src="/img/a.jpg"></a></body></html>'
+)
+_HTML_B = (
+    '<html><body><a href="/details.php?id=2" title="Beta Film / 2024">'
+    '<img src="/img/b.jpg"></a></body></html>'
+)
+
+
+class TestFetchListingOrigin(unittest.TestCase):
+    """`fetch_listing` surfaces the origin that actually served the HTML (#247):
+    kinozal.tv on primary success, kinozal.guru on mirror fallback — so the
+    pipeline can resolve links against the host the listing truly came from."""
+
+    def test_primary_success_returns_tv_base_url(self) -> None:
+        from kinozal_scraper.kinozal_pipeline import Kinozal
+
+        with unittest.mock.patch(
+            "kinozal_scraper.kinozal_pipeline.fetch_html", return_value=_KINOZAL_HTML
+        ):
+            html, base = Kinozal("u", "p").fetch_listing("https://kinozal.tv/top.php?d=14")
+        self.assertEqual(html, _KINOZAL_HTML)
+        self.assertEqual(base, "https://kinozal.tv")
+
+    def test_mirror_fallback_returns_guru_base_url(self) -> None:
+        from kinozal_scraper.kinozal_pipeline import Kinozal
+
+        sentinel = unittest.mock.Mock()
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_html",
+                side_effect=RuntimeError("HTTP Error 522"),
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_KINOZAL_HTML
+            ),
+        ):
+            html, base = Kinozal("u", "p").fetch_listing("https://kinozal.tv/top.php?d=14")
+        self.assertEqual(html, _KINOZAL_HTML)
+        self.assertEqual(base, "https://kinozal.guru")
+
+
+class TestLinkOriginFollowsHost(unittest.TestCase):
+    """End-to-end (#247): notification links resolve against the host that served
+    the listing. Injection stays on the HTTP boundary (fetch_html / login /
+    fetch_authenticated) — never mock Kinozal.fetch_listing/_from_mirror (§II)."""
+
+    _CREDS = {"KINOZAL_USERNAME": "u", "KINOZAL_PASSWORD": "p"}
+
+    def _run(self, urls: str) -> InMemoryNotifier:
+        full = {"URLS": urls, **self._CREDS}
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+        with unittest.mock.patch.dict(os.environ, full, clear=False):
+            run_kinozal_pipeline(storage, notifier, _FakeYoutube(), _SOURCES_CONFIG)
+        return notifier
+
+    def test_mirror_fallback_links_use_guru_origin(self) -> None:
+        sentinel = unittest.mock.Mock()
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_html",
+                side_effect=RuntimeError("HTTP Error 522"),
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_KINOZAL_HTML
+            ),
+        ):
+            notifier = self._run("top|https://kinozal.tv/top.php?d=14")
+        texts = "\n".join(n.text for n in notifier.sent)
+        self.assertIn("kinozal.guru/details.php", texts)
+        self.assertNotIn("kinozal.tv/details.php", texts)
+
+    def test_mirror_fallback_poster_uses_guru_origin(self) -> None:
+        sentinel = unittest.mock.Mock()
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_html",
+                side_effect=RuntimeError("HTTP Error 522"),
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_KINOZAL_HTML
+            ),
+        ):
+            notifier = self._run("top|https://kinozal.tv/top.php?d=14")
+        posters = [n.image_url for n in notifier.sent]
+        # item 1 has a relative poster (/img/p1.jpg); the mirror origin must win.
+        self.assertIn("https://kinozal.guru/img/p1.jpg", posters)
+
+    def test_mixed_origin_each_link_matches_its_listing(self) -> None:
+        def _fake_fetch(url: str) -> str:
+            if "d=14" in url:  # URL-A: primary .tv succeeds
+                return _HTML_A
+            raise RuntimeError("HTTP Error 522")  # URL-B: 522 → mirror
+
+        sentinel = unittest.mock.Mock()
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_html", side_effect=_fake_fetch
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.login", return_value=sentinel
+            ),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=_HTML_B
+            ),
+        ):
+            notifier = self._run(
+                "a|https://kinozal.tv/top.php?d=14;b|https://kinozal.tv/top.php?d=0"
+            )
+        alpha = next(n for n in notifier.sent if "Alpha Film" in n.text)
+        beta = next(n for n in notifier.sent if "Beta Film" in n.text)
+        self.assertIn("kinozal.tv/details.php?id=1", alpha.text)  # served by primary
+        self.assertIn("kinozal.guru/details.php?id=2", beta.text)  # served by mirror
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Что и зачем

Когда `kinozal.tv` отдаёт 522 и листинг тянется с зеркала `kinozal.guru` (fallback #227), ссылки
в Telegram-уведомлениях вели на `kinozal.tv` — мёртвые в момент отправки (пример: прогон
[28496637174](https://github.com/ekolvah/kinozal_scraper/actions/runs/28496637174), «Hidden Portals:
Вечное равновесие» → `kinozal.tv/details.php?id=2101698`).

**Root cause:** `base_url` захардкожен в `sources.json`, а `Kinozal.fetch_listing` возвращал только
HTML — origin, реально отдавший контент, терялся до extraction.

**Fix:** `fetch_listing → (html, effective_base_url)` (`.tv` при успехе primary, `.guru` при
mirror-fallback). Пайплайн резолвит относительные `url`/`image_url` против этого хоста (per-fetch
override статичного `base_url` через non-mutating `{**source, ...}`). Постеры `/i/poster/` следуют
за origin тем же override. Осознанный разворот #227/#241 (основание — получатель залогинен на `.guru`).

## Разворот прежнего решения

#227/#241 держали `base_url` всегда `.tv` как «canonical origin для ссылок». Отменяется сознательно:
получатель залогинен на зеркале, login-wall для него неактуален, живая `.guru`-ссылка лучше мёртвой
`.tv`. Синхронизировано в `docs/architecture/ci.md`.

## Тесты (TDD red→green)

5 RED-тестов в `test_kinozal_pipeline.py` (инъекция на HTTP-границе, §II — без мока `fetch_listing`):
`TestFetchListingOrigin` (primary→.tv / mirror→.guru base) + `TestLinkOriginFollowsHost`
(mirror-ссылки, mirror-постер, mixed-run). `test_build_notification_used_not_hardcoded` обновлён под
origin-following (было стале-ассертом `kinozal.tv`, `_run` фетчит `test.example`). 463 passed.

## Dedupe / миграция

`dedupe_key` — чистый title, host в ключ не входит → фильм, отданный `.tv` в один прогон и `.guru`
в другой, не задваивается; миграция старых `.tv`-строк в Sheet не нужна.

## Out of scope

- Постеры-fastpic (HTML-интерстишл при `200`) — отдельная тема.
- Прочие источники (json/steam/events/github).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
