### PR TITLE
feat(ci): complexity ratchet ruff C901 + PLR0912/PLR0915 (#233)

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -82,6 +82,33 @@ deferred to a Protocol-extraction refactor (#234 Out of scope). `principles.md`
 is deliberately **not** edited: §II is tool-agnostic canon, so the tool mention
 lives here and in `runtime.md`, not in the constitution.
 
+### Complexity ratchet (lint, #233)
+
+The `lint` check also enforces three ruff complexity rules — `C901` (mccabe
+cyclomatic), `PLR0912` (too-many-branches), `PLR0915` (too-many-statements) —
+as a **ratchet against method sprawl**: new/changed code over threshold fails
+CI, legacy is grandfathered. No new dependency; it rides on the existing
+`check_lint`. Thresholds: `max-complexity = 12` (`[tool.ruff.lint.mccabe]`),
+PLR0912/PLR0915 on ruff defaults (12 branches / 50 statements). The C901 value
+is **aligned with PLR0912's default branch threshold (12)**, not tuned to
+today's code — that keeps the choice defensible against Goodhart/bikeshedding.
+
+Six current violators are grandfathered with a per-function `# noqa: <exact
+codes>` on the `def` line (precise, self-documenting at the site — not a
+per-file ignore, which would blind the whole file to *new* sprawl).
+`tests/test_complexity_ratchet.py` is an anti-drift guard (mirrors
+`test_ruff_silence_rules.py` / `test_import_contracts.py`): it pins that the
+codes stay in the effective select and the threshold keeps its value, so the
+gate can't be silently gutted via `pyproject.toml`.
+
+**Known limitation:** a blanket `# noqa` lets a grandfathered function grow *more*
+complex undetected — ruff has no native baseline, so the ratchet protects new
+code and new functions, not the frozen six. The real fix is splitting them,
+tracked in #251 (§V documented-mitigation, not a silent assumption). `RUF100`
+(self-cleaning noqa) was considered but deferred: it flags 18 pre-existing
+unused-noqa across the repo — a separate cleanup, not this gate (#233 Out of
+scope).
+
 ## Claude review workflow (`claude-review.yml`)
 
 Triggers: every `pull_request: opened/synchronize`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,19 @@ select = [
     "SIM",
     "BLE",
     "TRY400",
+    # Complexity ratchet (#233) — hold back method sprawl on new/changed code.
+    "C901",     # mccabe cyclomatic complexity
+    "PLR0912",  # too-many-branches
+    "PLR0915",  # too-many-statements
 ]
 ignore = [
     "E501",
 ]
+
+[tool.ruff.lint.mccabe]
+# Align C901 with PLR0912's default branch threshold (12) rather than tuning to
+# today's code. PLR0912/PLR0915 stay on ruff defaults (12 branches / 50 statements).
+max-complexity = 12
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/kinozal_scraper/TelegramChannelSummarizer.py
+++ b/src/kinozal_scraper/TelegramChannelSummarizer.py
@@ -168,7 +168,7 @@ class TelethonReader:
     def fetch_channel(self, channel_url: str) -> ChannelMessages:
         return asyncio.run(self._fetch_channel_async(channel_url))
 
-    async def _fetch_channel_async(self, channel_url: str) -> ChannelMessages:
+    async def _fetch_channel_async(self, channel_url: str) -> ChannelMessages:  # noqa: C901, PLR0912
         target: str | int = channel_url
         if isinstance(channel_url, str) and channel_url.lstrip("-").isdigit():
             target = int(channel_url)

--- a/src/kinozal_scraper/gemini_enricher.py
+++ b/src/kinozal_scraper/gemini_enricher.py
@@ -272,7 +272,7 @@ class RotatingGeminiEnricher:
             self._current = (self._current + 1) % len(self._enrichers)
         return False
 
-    def enrich(self, item: NormalizedItem, enrich_config: dict[str, Any]) -> str:
+    def enrich(self, item: NormalizedItem, enrich_config: dict[str, Any]) -> str:  # noqa: C901, PLR0912
         last_exc: Exception | None = None
         # Cooldown only helps if some failure was Quota or Unavailable —
         # those can roll over / recover during the 60s wait. A pure

--- a/src/kinozal_scraper/github_trending_pipeline.py
+++ b/src/kinozal_scraper/github_trending_pipeline.py
@@ -89,7 +89,7 @@ def _enrich_with_stars_today(html: str, items: list[NormalizedItem]) -> None:
         item.raw["stars_today"] = by_href.get(key, "")
 
 
-def run_github_trending_pipeline(
+def run_github_trending_pipeline(  # noqa: C901, PLR0912, PLR0915
     storage: Storage,
     notifier: Notifier,
     enricher: Enricher | None = None,

--- a/src/kinozal_scraper/json_pipeline.py
+++ b/src/kinozal_scraper/json_pipeline.py
@@ -67,7 +67,7 @@ def run_json_pipeline(
     return results
 
 
-def _run_single_source(
+def _run_single_source(  # noqa: C901
     source: dict[str, Any],
     storage: Storage,
     notifier: Notifier,

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -264,7 +264,7 @@ def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
         return ""
 
 
-def run_kinozal_pipeline(
+def run_kinozal_pipeline(  # noqa: C901, PLR0912, PLR0915
     storage: Storage,
     notifier: Notifier,
     youtube: Any,

--- a/src/kinozal_scraper/pipeline_config.py
+++ b/src/kinozal_scraper/pipeline_config.py
@@ -92,7 +92,7 @@ def _check_no_residual_macros(value: Any, known_macros: list[str], path: str = "
             _check_no_residual_macros(item, known_macros, f"{path}[{i}]")
 
 
-def validate_sources_config(config: Any) -> None:
+def validate_sources_config(config: Any) -> None:  # noqa: C901, PLR0912
     if not isinstance(config, dict):
         raise ConfigError("Config must be a JSON object")
 

--- a/tests/test_complexity_ratchet.py
+++ b/tests/test_complexity_ratchet.py
@@ -1,0 +1,53 @@
+"""Anti-drift guard for the complexity ratchet ruff rules (#233).
+
+Method sprawl is held back by ruff `C901` (mccabe cyclomatic), `PLR0912`
+(too-many-branches) and `PLR0915` (too-many-statements), riding on the existing
+`check_lint` gate. This guard pins that the ratchet stays *active*: the codes are
+in the effective select and the mccabe threshold keeps its load-bearing value —
+so a future agent cannot quietly drop the gate by editing `pyproject.toml`.
+
+Mirrors `test_ruff_silence_rules.py` (silence gate, #231) and
+`test_import_contracts.py` (§II boundaries, #234): it pins *enforcement*, not
+mere declaration. It deliberately does not re-run ruff green — that is redundant
+with `check_lint` (testing.md "when a test is not worth writing").
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+_REPO = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO / "pyproject.toml"
+
+# Codes that must stay selected for the ratchet to bite new code.
+_COMPLEXITY_CODES = {"C901", "PLR0912", "PLR0915"}
+# Load-bearing: C901 aligned with PLR0912's default branch threshold (12), not
+# tuned to today's code. Changing it silently reshapes the gate — pin the value.
+_MCCABE_MAX_COMPLEXITY = 12
+
+
+def _lint_config() -> dict[str, Any]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return cast("dict[str, Any]", data["tool"]["ruff"]["lint"])
+
+
+class TestComplexityRatchet:
+    def test_rules_selected(self) -> None:
+        lint = _lint_config()
+        # Effective select (select ∪ extend-select) — robust to a future move to
+        # extend-select (mirrors test_ruff_silence_rules.py).
+        selected = set(lint.get("select", [])) | set(lint.get("extend-select", []))
+        assert selected >= _COMPLEXITY_CODES, (
+            "complexity ratchet codes must be in ruff select (#233 gate); "
+            f"missing: {_COMPLEXITY_CODES - selected}"
+        )
+
+    def test_mccabe_threshold_is_12(self) -> None:
+        lint = _lint_config()
+        mccabe = lint.get("mccabe", {})
+        assert mccabe.get("max-complexity") == _MCCABE_MAX_COMPLEXITY, (
+            "mccabe max-complexity must stay aligned with PLR0912 default (12); "
+            f"got {mccabe.get('max-complexity')!r}"
+        )


### PR DESCRIPTION
## Что и зачем

Включает complexity-метрики ruff как **ratchet против разрастания методов** (issue #233): `C901` (mccabe), `PLR0912` (branches), `PLR0915` (statements). Новый/изменённый код сверх порога падает в CI; 6 существующих нарушителей grandfather'нуты. Едет на существующем `check_lint` — **без новой зависимости**, runtime-токены = 0.

## Ключевые решения (после architect-review)

- **Порог `max-complexity = 12`** выровнен с дефолтным branch-порогом `PLR0912=12` — принципиально, не подгонка под текущий код (защита от Goodhart/bikeshedding). PLR0912/PLR0915 на дефолтах (12 веток / 50 стейтментов).
- **Grandfathering** — per-function `# noqa: <точные коды>` на строке `def` (не per-file ignore, который ослепил бы весь файл к новому росту). 6 функций:
  `validate_sources_config`, `run_github_trending_pipeline`, `run_kinozal_pipeline`, `enrich`, `_fetch_channel_async`, `_run_single_source`.
- **Anti-drift meta-тест** `tests/test_complexity_ratchet.py` — пинит присутствие кодов (effective select) + значение порога, чтобы гейт нельзя было тихо выпилить (§IV). Зеркалит `test_ruff_silence_rules` / `test_import_contracts`.
- **Known limitation (§V):** blanket `# noqa` не защищает grandfather'нутые функции от дальнейшего роста (у ruff нет baseline). Реальный fix — распил, tracking **#251**.
- **RUF100** (self-cleaning noqa) рассмотрен и отложен — даёт 18 unused-noqa по репо (отдельная уборка), см. #233 Out of scope.

## Проверка

- RED→GREEN: `check_red` (2 failed) → правка `pyproject.toml` + noqa → 2 passed.
- `python scripts/ci_check.py` зелёный целиком (format/lint/pytest/mypy/import-linter/…).

Closes #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
