### PR TITLE
label taxonomy: type axis → labels, title becomes plain description (#256)

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -25,11 +25,27 @@ git-запреты — в `.claude/settings.json` `permissions.deny`).
    into the branch being merged — with a **tracked follow-up issue** for the
    real fix — not a separate standalone fix PR (that costs an extra
    merge+rebase round-trip). Permanent changes are still split.
-5. **Issues carry labels** — every `gh issue create` includes `--label
-   bug|enhancement|documentation|testing|...`. Semantics: `bug` = something
-   broken / current behaviour wrong; `enhancement` = improvement / new feature
-   / quality; `documentation` = `*.md`/`docs/`-only; `testing` = test-coverage
-   work. Full set: `gh label list` (don't hard-code the list here — it drifts).
+5. **Issues carry exactly one type-label** — the *type* of change lives in a
+   label, **not** in the title (the title is a plain description). `gh issue
+   create` sets exactly one label off the **type axis** (a *closed* semantic
+   set of nine — spelling it out here is a spec of the axis, not a hard-coded
+   drifting list). The type-label is the creator's call; `/plan` never touches
+   labels (`commands/plan.md`). Pick it by this **first-match** tree:
+     1. Something is broken / current behaviour is wrong → **`bug`**.
+     2. Changes user-visible behaviour or value: speed-only → **`perf`**;
+        closes a vulnerability / hardening → **`security`**; otherwise →
+        **`enhancement`**.
+     3. Behaviour unchanged: production code under `src/` (structure) →
+        **`refactor`**; `tests/`-only → **`testing`**; CI pipeline / quality
+        gates (`.github/workflows`, `ci_check`, lint/type/audit config) →
+        **`ci`**; `*.md`/`docs/`-only → **`documentation`**; other housekeeping
+        (non-CI dev scripts, dep bumps, repo config) → **`chore`**.
+   Example: `gh issue create --label refactor` (one, off the tree). Git *commit*
+   messages keep their conventional prefixes (`feat(ci): …` — changelog/history
+   is a separate axis from the issue title). The full set of **non-type** labels
+   (`wontfix`, `duplicate`, `help wanted`, future area-labels) still lives in
+   `gh label list` (don't hard-code *those* here — they drift); the type axis
+   above is closed and canonical.
 6. **Pre-commit gate** — `python scripts/ci_check.py` runs ruff format +
    lint + pytest + mypy + pip-audit + lockfile drift. The `.githooks/pre-push`
    hook runs it automatically; do not bypass with `--no-verify`.

--- a/scripts/issue_branch.py
+++ b/scripts/issue_branch.py
@@ -22,9 +22,12 @@ FALLBACK_SLUG = "task"
 _PREFIX_TAG_RE = re.compile(r"^\s*\[[^\]]+\]\s*")
 # Conventional-commit type prefix (`feat:`, `refactor(ci):`) — since #256 the
 # type lives in a label, not the title, but a leftover prefix must not leak
-# into the slug. Lowercase word + optional (scope) + colon + space (the
-# space keeps it from eating `label-таксономии:` / `url:8080`).
-_PREFIX_TYPE_RE = re.compile(r"^\s*[a-z]+(?:\([^)]*\))?:\s+")
+# into the slug. Anchored to the *closed* type axis from workflow.md #5 (not a
+# bare `\w+`), so a plain title like `docker: bump base image` keeps its first
+# word. Optional (scope) + colon + space (the space keeps it from eating
+# `label-таксономии:` / `url:8080`).
+_TYPE_AXIS = "bug|enhancement|refactor|perf|security|testing|ci|documentation|chore|feat|fix|docs"
+_PREFIX_TYPE_RE = re.compile(rf"^\s*(?:{_TYPE_AXIS})(?:\([^)]*\))?:\s+")
 
 
 def slugify(title: str) -> str:

--- a/scripts/issue_branch.py
+++ b/scripts/issue_branch.py
@@ -19,12 +19,10 @@ from pathlib import Path
 
 MAX_SLUG_WORDS = 4
 FALLBACK_SLUG = "task"
-_PREFIX_TAG_RE = re.compile(r"^\s*\[[^\]]+\]\s*")
 
 
 def slugify(title: str) -> str:
-    no_tag = _PREFIX_TAG_RE.sub("", title)
-    ascii_only = re.sub(r"[^a-zA-Z0-9\s-]", " ", no_tag).lower()
+    ascii_only = re.sub(r"[^a-zA-Z0-9\s-]", " ", title).lower()
     words = [w for w in re.split(r"[\s-]+", ascii_only) if w]
     if not words:
         return FALLBACK_SLUG

--- a/scripts/issue_branch.py
+++ b/scripts/issue_branch.py
@@ -20,10 +20,15 @@ from pathlib import Path
 MAX_SLUG_WORDS = 4
 FALLBACK_SLUG = "task"
 _PREFIX_TAG_RE = re.compile(r"^\s*\[[^\]]+\]\s*")
+# Conventional-commit type prefix (`feat:`, `refactor(ci):`) — since #256 the
+# type lives in a label, not the title, but a leftover prefix must not leak
+# into the slug. Lowercase word + optional (scope) + colon + space (the
+# space keeps it from eating `label-таксономии:` / `url:8080`).
+_PREFIX_TYPE_RE = re.compile(r"^\s*[a-z]+(?:\([^)]*\))?:\s+")
 
 
 def slugify(title: str) -> str:
-    no_tag = _PREFIX_TAG_RE.sub("", title)
+    no_tag = _PREFIX_TYPE_RE.sub("", _PREFIX_TAG_RE.sub("", title))
     ascii_only = re.sub(r"[^a-zA-Z0-9\s-]", " ", no_tag).lower()
     words = [w for w in re.split(r"[\s-]+", ascii_only) if w]
     if not words:

--- a/scripts/issue_branch.py
+++ b/scripts/issue_branch.py
@@ -20,18 +20,10 @@ from pathlib import Path
 MAX_SLUG_WORDS = 4
 FALLBACK_SLUG = "task"
 _PREFIX_TAG_RE = re.compile(r"^\s*\[[^\]]+\]\s*")
-# Conventional-commit type prefix (`feat:`, `refactor(ci):`) — since #256 the
-# type lives in a label, not the title, but a leftover prefix must not leak
-# into the slug. Anchored to the *closed* type axis from workflow.md #5 (not a
-# bare `\w+`), so a plain title like `docker: bump base image` keeps its first
-# word. Optional (scope) + colon + space (the space keeps it from eating
-# `label-таксономии:` / `url:8080`).
-_TYPE_AXIS = "bug|enhancement|refactor|perf|security|testing|ci|documentation|chore|feat|fix|docs"
-_PREFIX_TYPE_RE = re.compile(rf"^\s*(?:{_TYPE_AXIS})(?:\([^)]*\))?:\s+")
 
 
 def slugify(title: str) -> str:
-    no_tag = _PREFIX_TYPE_RE.sub("", _PREFIX_TAG_RE.sub("", title))
+    no_tag = _PREFIX_TAG_RE.sub("", title)
     ascii_only = re.sub(r"[^a-zA-Z0-9\s-]", " ", no_tag).lower()
     words = [w for w in re.split(r"[\s-]+", ascii_only) if w]
     if not words:

--- a/tests/test_issue_branch.py
+++ b/tests/test_issue_branch.py
@@ -13,12 +13,6 @@ class TestSlugify:
     def test_ascii_title_lowercased_and_dashed(self) -> None:
         assert slugify("Fix Telegram Notifier Bug") == "fix-telegram-notifier-bug"
 
-    def test_strips_type_prefix_tag(self) -> None:
-        assert slugify("[bug] gemini truncates summary") == "gemini-truncates-summary"
-
-    def test_strips_feat_prefix_tag(self) -> None:
-        assert slugify("[feat] Add github trending source") == "add-github-trending-source"
-
     def test_caps_at_four_words(self) -> None:
         assert slugify("one two three four five six") == "one-two-three-four"
 
@@ -26,7 +20,7 @@ class TestSlugify:
         assert slugify("починить геминай") == "task"
 
     def test_mixed_ascii_and_cyrillic_keeps_ascii(self) -> None:
-        assert slugify("[bug] gemini обрезает summary") == "gemini-summary"
+        assert slugify("gemini обрезает summary") == "gemini-summary"
 
     def test_empty_title_falls_back_to_task(self) -> None:
         assert slugify("") == "task"
@@ -37,7 +31,7 @@ class TestSlugify:
 
 class TestBuildBranchName:
     def test_concatenates_with_issue_number(self) -> None:
-        assert build_branch_name(114, "[feat] add commands") == "issue-114-add-commands"
+        assert build_branch_name(114, "add commands") == "issue-114-add-commands"
 
     def test_falls_back_when_slug_empty(self) -> None:
         assert build_branch_name(42, "русский тайтл") == "issue-42-task"
@@ -61,7 +55,7 @@ class TestBuildBranchName:
 
 class TestFetchTitleEncoding:
     def test_cyrillic_title_decodes(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        cyrillic_title = "[bug] /plan и /implement не работают после PR #121"
+        cyrillic_title = "/plan и /implement не работают после PR #121"
         payload = json.dumps({"state": "OPEN", "title": cyrillic_title}, ensure_ascii=False)
 
         def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:

--- a/tests/test_issue_branch.py
+++ b/tests/test_issue_branch.py
@@ -34,18 +34,6 @@ class TestSlugify:
     def test_special_chars_dropped(self) -> None:
         assert slugify("Add /plan + /implement commands!") == "add-plan-implement-commands"
 
-    def test_strips_conventional_type_prefix(self) -> None:
-        # Type moved out of the title into a label (#256); a leftover conventional
-        # prefix must not leak into the branch slug (feat/ci/scope are noise).
-        assert slugify("feat(ci): add complexity ratchet") == "add-complexity-ratchet"
-        assert slugify("refactor: unify extraction guard") == "unify-extraction-guard"
-
-    def test_keeps_non_type_word_before_colon(self) -> None:
-        # Anchored to the closed type axis: a plain title that merely starts with
-        # `word:` (not a real type) keeps its first word — no over-stripping.
-        assert slugify("docker: bump base image version") == "docker-bump-base-image"
-        assert slugify("note: revisit rate limiting") == "note-revisit-rate-limiting"
-
 
 class TestBuildBranchName:
     def test_concatenates_with_issue_number(self) -> None:

--- a/tests/test_issue_branch.py
+++ b/tests/test_issue_branch.py
@@ -34,6 +34,12 @@ class TestSlugify:
     def test_special_chars_dropped(self) -> None:
         assert slugify("Add /plan + /implement commands!") == "add-plan-implement-commands"
 
+    def test_strips_conventional_type_prefix(self) -> None:
+        # Type moved out of the title into a label (#256); a leftover conventional
+        # prefix must not leak into the branch slug (feat/ci/scope are noise).
+        assert slugify("feat(ci): add complexity ratchet") == "add-complexity-ratchet"
+        assert slugify("refactor: unify extraction guard") == "unify-extraction-guard"
+
 
 class TestBuildBranchName:
     def test_concatenates_with_issue_number(self) -> None:

--- a/tests/test_issue_branch.py
+++ b/tests/test_issue_branch.py
@@ -40,6 +40,12 @@ class TestSlugify:
         assert slugify("feat(ci): add complexity ratchet") == "add-complexity-ratchet"
         assert slugify("refactor: unify extraction guard") == "unify-extraction-guard"
 
+    def test_keeps_non_type_word_before_colon(self) -> None:
+        # Anchored to the closed type axis: a plain title that merely starts with
+        # `word:` (not a real type) keeps its first word — no over-stripping.
+        assert slugify("docker: bump base image version") == "docker-bump-base-image"
+        assert slugify("note: revisit rate limiting") == "note-revisit-rate-limiting"
+
 
 class TestBuildBranchName:
     def test_concatenates_with_issue_number(self) -> None:


### PR DESCRIPTION
## Что и зачем

Реформа label-таксономии (issue #256): **ось «тип задачи» переезжает из тайтла issue в labels**, тайтл становится чистым описанием. Мотивация — тип, зашитый в тайтл (`refactor(ci):`), не давал отличить «новую ценность юзеру» от «внутренней чистки», и `refactor` вынужденно жил под `enhancement`.

## Изменения в этом PR

- **`.claude/rules/workflow.md #5`** переписан:
  - Ось «тип» — **закрытое множество из 9 типов** (bug/enhancement/refactor/perf/security/testing/ci/documentation/chore) с **first-match decision-tree** для детерминированного выбора.
  - **Ровно один type-label** на issue, ставится при `gh issue create`; `/plan` labels не трогает.
  - Прочие (нетиповые) labels остаются делегированы `gh label list` (устранено противоречие «перечислить типы» vs «не хардкодить», которое поймал architect-review).
  - Git **commit**-messages сохраняют conventional-префиксы (отдельная ось: changelog/история кода).
- **`scripts/issue_branch.py`** — `slugify` **упрощён**: удалены обе префикс-регулярки (`_PREFIX_TAG_RE` для `[bug]` и добавленная-затем-снятая `_PREFIX_TYPE_RE`). Раз тип ушёл из тайтла, стрип типа-префикса из имени ветки — мёртвый код. Теперь `slugify` = тайтл → ASCII-слова → дефисы. (Имя ветки временное и не принципиально — решение владельца.)

## Out-of-band (GitHub-state, вне диффа)

- Созданы 5 labels: `refactor`, `chore`, `ci`, `perf`, `security`.
- 7 открытых issue переразмечены по дереву (по одному type-label) и переименованы без типа-префикса: #253→ci, #254→chore, #255→ci, #251→refactor, #236→ci, #235→ci, #104→refactor; сама #256→chore.

## Проверка

`python scripts/ci_check.py` зелёный целиком (465 passed). `slugify`-тесты обновлены под упрощение (сняты tag-strip кейсы).

## История решения

- architect-review (BLOCKING — нет): разведены закрытая ось «тип» и делегированный список; добавлено decision-tree; машинный гейт «один type-label» **сознательно не строим** (захардкодил бы type-set против политики «не дрейфовать»).
- claude-review нашёл over-broad regex в slug-подстраховке → в итоге подстраховку **убрали целиком** (владелец: имя ветки не важно, важна чистота тайтла issue — а её обеспечивает сама реформа, не slugify).

Closes #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
