### PR TITLE
PR template: delivery-only Risk & Rollback + divergence prompt

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,21 @@
 <!--
-PR template для kinozal_scraper. Контракт: все три секции обязательны. PR — это отчёт
-по плану из issue. Если issue нет (тривиальный фикс) — всё равно заполни все секции.
+PR template для kinozal_scraper. Все секции обязательны.
+
+PR — это ОТЧЁТ по плану из issue (что реально сделано + доказательство), а не копия
+issue. `Test plan` и `Docs touched` зеркалят одноимённые issue-секции как ПЛАН→ФАКТ
+(галочки = прогнано). `Risk & Rollback` — delivery-only: у неё counterpart'а в issue
+нет и быть не может (blast-radius известен только по факту диффа).
+
+Если issue нет (тривиальный фикс) — всё равно заполни все секции.
 -->
 
 ## Summary
 
-<!-- 2-3 предложения: что сделано и зачем. Linker `Closes #N` (или `Refs #N`) обязателен. -->
+<!--
+2-3 предложения: что сделано и зачем. Linker `Closes #N` (или `Refs #N`) обязателен.
+Divergence: совпало с issue `## Implementation outline`? Отклонения/сюрпризы — одной строкой
+(или «совпало с планом»).
+-->
 
 Closes #
 
@@ -18,6 +28,17 @@ Markdown-чеклист. Должен зеркалить issue'шный `## Test
 
 - [ ] `python scripts/ci_check.py` — green локально
 - [ ] CI на PR — green
+
+## Risk & Rollback
+
+<!--
+Проверяемо за 30 сек. Для тривиального изменения — одна строка «low risk, revert-safe».
+- Blast-radius: изменение изолировано или задевает несвязанное (крон-пайплайн,
+  Sheets-дедуп, Telegram-доставка, Gemini)?
+- Rollback: чистый `git revert` PR — или есть необратимые эффекты (уже отправленные
+  Telegram-сообщения, записи в Google Sheets)?
+- Мониторинг: за чем следить после мержа (ближайший крон-ран run-script.yml)?
+-->
 
 ## Docs touched
 

--- a/tests/test_pr_template.py
+++ b/tests/test_pr_template.py
@@ -1,0 +1,40 @@
+"""Anti-drift guard for the PR template's required H2 sections.
+
+WHAT THIS PINS — and what it deliberately does NOT: this test asserts the
+presence of *human-facing prompts* (H2 headers) in the markdown PR template.
+Those headers have **no machine enforcement downstream** — there is no gate
+that parses a PR body, and building one is consciously out of scope (#258:
+cosmetic failure, solo-repo, priority-3 → work-for-work). So this is **not**
+an analogue of `test_complexity_ratchet`, which pins a *live ruff gate* that
+actually reddens new code; dropping a header here weakens a checklist, not an
+enforced rule.
+
+Its only justification is §IV (visibility over silence): a silent drop of the
+`Risk & Rollback` prompt — the one delivery-only section (blast-radius / rollback
+/ cron-monitoring) that has no issue counterpart — becomes a visible red instead
+of quiet drift. Do NOT read this as a live gate and start building a PR-body
+parser around it; that would be the work-for-work #258 explicitly rejected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REQUIRED_PR_SECTIONS: tuple[str, ...] = (
+    "Summary",
+    "Test plan",
+    "Risk & Rollback",
+    "Docs touched",
+)
+
+
+def _template_text() -> str:
+    path = Path(__file__).resolve().parent.parent / ".github" / "pull_request_template.md"
+    return path.read_text(encoding="utf-8")
+
+
+class TestPrTemplate:
+    def test_all_required_sections_present(self) -> None:
+        text = _template_text()
+        missing = [name for name in REQUIRED_PR_SECTIONS if f"## {name}" not in text]
+        assert not missing, f"PR template missing required H2 sections: {missing}"


### PR DESCRIPTION
## Summary

PR-шаблон (`.github/pull_request_template.md`) перестаёт быть бледным эхом issue и добавляет delivery-only секцию `## Risk & Rollback` (blast-radius / откат / мониторинг крона) + prompt-строку divergence-from-plan внутри `## Summary`. Шапка-комментарий теперь фиксирует контракт «PR = отчёт по плану issue, не копия» и природу overlap (`Test plan`/`Docs touched` = план→факт, `Risk & Rollback` = delivery-only). Anti-drift meta-тест пинит набор обязательных H2.

Closes #258

Divergence: совпало с issue `## Implementation outline`. Взяты обе architect-правки (один тест вместо двух, честный docstring; commit `docs(ci)` вместо `feat`). Docs-шаг ожидаемо без правок — хардкода набора секций в репо нет (шаблон упомянут только по пути в `implement.md:16`).

## Test plan

- [x] `tests/test_pr_template.py::TestPrTemplate::test_all_required_sections_present` — RED до правки шаблона (`Risk & Rollback` отсутствовал) → GREEN после
- [x] `python scripts/check_red.py tests/test_pr_template.py` — подтвердил RED (1 failed)
- [x] `python scripts/ci_check.py` — green локально
- [ ] CI на PR — green

## Risk & Rollback

low risk, revert-safe. Изменение изолировано: правка markdown-шаблона + один guard-тест, production-логики и рантайм-путей не касается (крон-пайплайн / Sheets / Telegram / Gemini не затронуты). Rollback — чистый `git revert`, необратимых эффектов нет. Мониторить нечего: шаблон влияет только на UX создания будущих PR, не на прод-ран run-script.yml.

## Docs touched

none — behaviour unchanged. Сам шаблон `.github/pull_request_template.md` — целевой артефакт (не doc про поведение кода). Хардкода набора PR-секций в `docs/` / `.claude/commands/` нет (проверено grep + architect-review), правок doc-файлов не потребовалось.
