### PR TITLE
feat(ci): ruff ERA001 dead-code ratchet

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -109,6 +109,30 @@ tracked in #251 (§V documented-mitigation, not a silent assumption). `RUF100`
 unused-noqa across the repo — a separate cleanup, not this gate (#233 Out of
 scope).
 
+### Dead-code ratchet (lint, #235)
+
+The `lint` check also enforces ruff `ERA001` (commented-out code) as a
+**preventive ratchet**: new commented-out code fails CI. No new dependency; it
+rides on the existing `check_lint`. The repo measured **clean** — the only hit
+was an illustrative schema comment (`# [dedupe_key, title, ...]`) that ruff
+mis-parses as a list literal; it was fixed by **rewording to prose**, not a
+`# noqa` (the code was never dead, so suppressing a real detector would train
+the escape hatch on a non-exception — §IV). For a *genuine* future false
+positive, the escape hatch is a per-site `# noqa: ERA001` with a reason, not a
+per-file ignore. `tests/test_ruff_dead_code_rule.py` is an anti-drift guard
+(mirrors `test_ruff_silence_rules.py` / `test_complexity_ratchet.py`): it pins
+that `ERA001` stays in the effective select and is not neutralised via
+`ignore` / `per-file-ignores`.
+
+**`vulture` (cross-module unused) was consciously dropped**, not added: the repo
+measured **zero** cross-module dead code, and local unused is already caught by
+ruff `F` (F401/F841). vulture is FP-prone on this codebase's dynamic shape
+(pipeline registry, declarative config, `Protocol` impls, pytest fixtures,
+`__main__` entrypoints) — it would add a dependency, a gate and a whitelist that
+needs per-CI triage, to guard a hypothetical. Deferred **wait-for-pain**: revisit
+if real cross-module dead code appears that `ERA001` cannot catch (#235 Out of
+scope).
+
 ## Claude review workflow (`claude-review.yml`)
 
 Triggers: every `pull_request: opened/synchronize`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,8 @@ select = [
     "SIM",
     "BLE",
     "TRY400",
+    # Dead-code ratchet (#235) — flag commented-out code on new/changed code.
+    "ERA001",
     # Complexity ratchet (#233) — hold back method sprawl on new/changed code.
     "C901",     # mccabe cyclomatic complexity
     "PLR0912",  # too-many-branches

--- a/tests/test_github_trending_pipeline.py
+++ b/tests/test_github_trending_pipeline.py
@@ -248,8 +248,8 @@ class TestMetricColumnSemantics(unittest.TestCase):
         storage, _ = _run()
         rows = storage.stored_rows("github_projects")
         self.assertGreaterEqual(len(rows), 1)
-        # Row schema (generic_pipeline.ROW_HEADERS):
-        # [dedupe_key, title, url, metric, source_id, notified_at]
+        # Row columns (generic_pipeline.ROW_HEADERS): dedupe_key, title, url,
+        # metric, source_id, notified_at
         for row in rows:
             metric = str(row[3])
             with self.subTest(metric=metric):

--- a/tests/test_ruff_dead_code_rule.py
+++ b/tests/test_ruff_dead_code_rule.py
@@ -1,0 +1,68 @@
+"""Anti-drift guard for the dead-code detection ruff rule (#235).
+
+Commented-out code is caught by ruff `ERA001` as a **preventive ratchet**: the
+repo measured clean (the sole hit was an illustrative schema comment, a false
+positive fixed by rewording — no cross-module dead code found, so `vulture` was
+consciously dropped, see `docs/architecture/ci.md`). Value is a forcing-function
+on *new* commented-out code, not cleanup of existing.
+
+This guard asserts the code stays *active*: present in the effective select AND
+not silently neutralised via `ignore` / `per-file-ignores`. Mirrors
+`test_ruff_silence_rules.py` (#231) and `test_complexity_ratchet.py` (#233) — it
+pins *enforcement*, not mere declaration, so a future agent cannot quietly drop
+the gate through any of the disable vectors. It deliberately does not re-run ruff
+green — that is redundant with the live `check_lint` gate (testing.md "when a
+test is not worth writing").
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+_REPO = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO / "pyproject.toml"
+
+# Code that must be selected. ruff config may carry it prefix or full.
+_DEAD_CODE_CODES = {"ERA001"}
+# Any of these tokens, if present in ignore / per-file-ignores, disables the
+# dead-code rule while leaving `select` untouched — the threat-model of #235.
+_DISABLE_TOKENS = {"ERA", "ERA001"}
+
+
+def _lint_config() -> dict[str, Any]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return cast("dict[str, Any]", data["tool"]["ruff"]["lint"])
+
+
+class TestRuffDeadCodeRule:
+    def test_dead_code_rule_active(self) -> None:
+        lint = _lint_config()
+
+        # (a) present in effective select (select ∪ extend-select) — robust to
+        # a future move to extend-select (mirrors test_ruff_silence_rules.py).
+        selected = set(lint.get("select", [])) | set(lint.get("extend-select", []))
+        assert selected >= _DEAD_CODE_CODES, (
+            "dead-code detection code must be in ruff select (#235 gate); "
+            f"missing: {_DEAD_CODE_CODES - selected}"
+        )
+
+        # (b) not neutralised via ignore.
+        ignored = set(lint.get("ignore", []))
+        assert not (_DISABLE_TOKENS & ignored), (
+            "dead-code code must not appear in ruff `ignore` (silently disables "
+            f"the #235 gate): {_DISABLE_TOKENS & ignored}"
+        )
+
+        # (c) not neutralised via per-file-ignores.
+        per_file = lint.get("per-file-ignores", {})
+        leaked = {
+            path: sorted(_DISABLE_TOKENS & set(codes))
+            for path, codes in per_file.items()
+            if _DISABLE_TOKENS & set(codes)
+        }
+        assert not leaked, (
+            "dead-code code must not appear in `per-file-ignores` (silently "
+            f"disables the #235 gate): {leaked}"
+        )


### PR DESCRIPTION
## Summary

Включает ruff `ERA001` (закомментированный код) как **превентивный dead-code ratchet** на существующем `check_lint`-гейте — ноль новых зависимостей. Репо измеренно чист: единственный хит — иллюстративный коммент схемы (`# [dedupe_key, title, ...]`), который ruff ошибочно парсит как list-literal; снят **рефразом в прозу**, не `# noqa` (код не был мёртвым → глушить реальный детектор = тренировать escape hatch на не-исключении, §IV). Anti-drift тест пинит, что правило не выпилить тихо. `vulture` **сознательно дропнут** (0 кросс-модульного dead-code, FP-prone на этом коде → work-for-work, wait-for-pain).

Closes #235

Divergence: совпало с issue `## Implementation outline`. Учтён нюанс architect'а — после рефраза прогнан `ruff check .` целиком (не только ERA001): рефраз-строка не триггерит других правил. NICE-отметка (дедуп `_lint_config()` в трёх ratchet-тестах) осознанно не бралась — прецедент = отдельный файл per-ratchet.

## Test plan

- [x] `tests/test_ruff_dead_code_rule.py::TestRuffDeadCodeRule::test_dead_code_rule_active` — RED до правки (`ERA001` не в select) → GREEN после
- [x] `python scripts/check_red.py tests/test_ruff_dead_code_rule.py` — подтвердил RED (1 failed)
- [x] `python -m ruff check .` — clean (рефраз-коммент не триггерит другие правила)
- [x] `python scripts/ci_check.py` — green локально
- [ ] CI на PR — green

## Risk & Rollback

low risk, revert-safe. Изменение изолировано: правка lint-конфига (`pyproject.toml` select) + рефраз одного коммента-документации в тесте + anti-drift guard-тест + docs. Production-логики и рантайм-путей не касается — крон-пайплайн / Sheets-дедуп / Telegram-доставка / Gemini не затронуты. Rollback — чистый `git revert`, необратимых эффектов нет. Мониторить нечего: ERA001 влияет только на CI-гейт будущих PR, не на прод-ран run-script.yml.

## Docs touched

- `docs/architecture/ci.md` — новая под-секция `### Dead-code ratchet (lint, #235)` рядом с complexity/silence-ratchet: что, почему превентивно, escape hatch (per-site noqa), anti-drift guard, зафиксированный отказ от vulture.
- `docs/architecture/principles.md` — НЕ трогали (§IV/§V tool-agnostic canon; tool-mention живёт в ci.md, как для #233/#234).
