### PR TITLE
refactor(scripts): drop interpreter re-spawn in issue_branch, call create_branch in-process

### DIFF
--- a/scripts/issue_branch.py
+++ b/scripts/issue_branch.py
@@ -16,6 +16,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 MAX_SLUG_WORDS = 4
 FALLBACK_SLUG = "task"
@@ -29,12 +30,19 @@ def slugify(title: str) -> str:
     return "-".join(words[:MAX_SLUG_WORDS])
 
 
-def _branch_prefix() -> str:
-    """Single source of truth for the prefix: `new_branch.BRANCH_PREFIX`.
+def _new_branch_module() -> ModuleType:
+    """Load the sibling `new_branch.py` by absolute path and return the module.
 
-    Loaded by path (scripts/ is not a package) so this value cannot drift from
-    the guard in `new_branch.py` that validates the produced branch name — a
-    drift would silently break the `issue_branch.py → new_branch.py` pipeline.
+    Loaded by absolute file path — NOT `from scripts.new_branch import ...` —
+    because the documented CLI `python scripts/issue_branch.py <N>` sets
+    `sys.path[0]` to the script's dir (`scripts/`), and the repo root is never
+    on `sys.path` (the editable install only adds `src/`). A package import
+    would therefore raise `ModuleNotFoundError` at runtime even though
+    `scripts/` IS a package (packageness is necessary but not sufficient; tests
+    pass only because `python -m pytest` prepends the repo root). The path load
+    is immune to `sys.path`, gives a single source of truth for
+    `BRANCH_PREFIX`, and lets `main()` call `create_branch` in-process instead
+    of re-spawning a second interpreter.
     """
     spec = importlib.util.spec_from_file_location(
         "scripts.new_branch", Path(__file__).with_name("new_branch.py")
@@ -42,11 +50,11 @@ def _branch_prefix() -> str:
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    return str(module.BRANCH_PREFIX)
+    return module
 
 
 def build_branch_name(issue_number: int, title: str) -> str:
-    return f"{_branch_prefix()}{issue_number}-{slugify(title)}"
+    return f"{_new_branch_module().BRANCH_PREFIX}{issue_number}-{slugify(title)}"
 
 
 def _fetch_title(issue_number: int) -> str:
@@ -78,8 +86,7 @@ def main() -> None:
         sys.exit(2)
     title = _fetch_title(n)
     branch = build_branch_name(n, title)
-    new_branch = Path(__file__).with_name("new_branch.py")
-    subprocess.run([sys.executable, str(new_branch), branch], check=True)
+    _new_branch_module().create_branch(branch)
 
 
 if __name__ == "__main__":

--- a/scripts/new_branch.py
+++ b/scripts/new_branch.py
@@ -71,11 +71,16 @@ def _prune_gone_branches() -> None:
     print(f"pruned: {pruned} merged branches (skipped {skipped} unmerged)")
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print("Usage: python scripts/new_branch.py <branch-name>", file=sys.stderr)
-        sys.exit(2)
-    name = sys.argv[1]
+def create_branch(name: str) -> None:
+    """Create branch `name` from a fresh origin/main HEAD.
+
+    Validates the prefix, refuses a dirty tree or an already-existing branch,
+    syncs main (checkout + ff-only pull), prunes merged `[gone]` branches, then
+    branches. Every failure path raises (SystemExit via `sys.exit`, or
+    CalledProcessError from `_run(check=True)`), so a caller driving this
+    in-process — `issue_branch.py` — surfaces the failure as a non-zero exit
+    instead of silently continuing (§IV visibility).
+    """
     if not is_valid_branch_name(name):
         print(
             f"error: branch name must start with {BRANCH_PREFIX!r} (got {name!r})", file=sys.stderr
@@ -98,6 +103,13 @@ def main() -> None:
     _prune_gone_branches()
     _run(["git", "checkout", "-b", name])
     print(f"ready: on {name}, branched from origin/main HEAD")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: python scripts/new_branch.py <branch-name>", file=sys.stderr)
+        sys.exit(2)
+    create_branch(sys.argv[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_branch.py
+++ b/tests/test_issue_branch.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from typing import Any
 
 import pytest
 
+import scripts.issue_branch as issue_branch
 from scripts.issue_branch import _fetch_title, build_branch_name, slugify
 
 
@@ -66,3 +68,42 @@ class TestFetchTitleEncoding:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         assert _fetch_title(122) == cyrillic_title
+
+
+class TestDirectDelegation:
+    """`issue_branch.main()` must build the branch in-process via
+    `new_branch.create_branch`, not by re-spawning a second interpreter
+    (`subprocess.run([sys.executable, ...])`, #254). This is also the first
+    coverage of `main()`'s orchestration.
+    """
+
+    def test_main_delegates_to_create_branch_in_process(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[str] = []
+
+        class _FakeNewBranch:
+            BRANCH_PREFIX = "issue-"
+
+            @staticmethod
+            def create_branch(name: str) -> None:
+                calls.append(name)
+
+        monkeypatch.setattr(issue_branch, "_fetch_title", lambda n: "add commands")
+        # Single seam for both the prefix (build_branch_name) and the branch
+        # creation, so patching it fully isolates the git side-effects.
+        monkeypatch.setattr(
+            issue_branch, "_new_branch_module", lambda: _FakeNewBranch, raising=False
+        )
+        # Spy so the pre-refactor re-spawn path cannot shell out to real git
+        # during RED; the contract asserted below is the delegate call, not this.
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda *a, **k: subprocess.CompletedProcess(a[0] if a else [], 0, "", ""),
+        )
+        monkeypatch.setattr(sys, "argv", ["issue_branch.py", "254"])
+
+        issue_branch.main()
+
+        assert calls == ["issue-254-add-commands"]

--- a/tests/test_new_branch.py
+++ b/tests/test_new_branch.py
@@ -132,5 +132,26 @@ class TestBranchNameGuard(unittest.TestCase):
         self.assertFalse(new_branch.is_valid_branch_name("foo-bar"))
 
 
+class TestCreateBranchVisibility(unittest.TestCase):
+    """The `create_branch` helper extracted from `main()` (#254) must keep the
+    dirty-tree guard a hard failure (non-zero exit), so a dirty working tree
+    cannot be silently skipped when `create_branch` is driven in-process from
+    `issue_branch` (§IV visibility).
+    """
+
+    def test_dirty_tree_exits_nonzero(self) -> None:
+        new_branch = _load_new_branch_module()
+
+        def fake_run(cmd: list[str], capture: bool = False) -> subprocess.CompletedProcess[str]:
+            if cmd[:3] == ["git", "status", "--porcelain"]:
+                return subprocess.CompletedProcess(cmd, 0, stdout=" M dirty.py\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with unittest.mock.patch.object(new_branch, "_run", side_effect=fake_run):
+            with self.assertRaises(SystemExit) as ctx:
+                new_branch.create_branch("issue-254-x")
+        self.assertNotEqual(ctx.exception.code, 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_new_branch.py
+++ b/tests/test_new_branch.py
@@ -1,7 +1,9 @@
 """Tests for `scripts/new_branch.py`.
 
-Loaded via `importlib.util` so we don't have to turn `scripts/` into a
-package or modify `pyproject.toml` testpaths.
+Loaded by absolute path via `importlib.util` (rather than
+`import scripts.new_branch`) so the test targets the module by file location
+regardless of `sys.path` — the same way the production `issue_branch.py` loads
+it under the `python scripts/issue_branch.py <N>` CLI.
 """
 
 from __future__ import annotations
@@ -147,9 +149,11 @@ class TestCreateBranchVisibility(unittest.TestCase):
                 return subprocess.CompletedProcess(cmd, 0, stdout=" M dirty.py\n", stderr="")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        with unittest.mock.patch.object(new_branch, "_run", side_effect=fake_run):
-            with self.assertRaises(SystemExit) as ctx:
-                new_branch.create_branch("issue-254-x")
+        with (
+            unittest.mock.patch.object(new_branch, "_run", side_effect=fake_run),
+            self.assertRaises(SystemExit) as ctx,
+        ):
+            new_branch.create_branch("issue-254-x")
         self.assertNotEqual(ctx.exception.code, 0)
 
 


### PR DESCRIPTION
## Summary

Closes #254.

`issue_branch.py` создавало ветку, **ре-спавня второй Python-интерпретатор**: `subprocess.run([sys.executable, new_branch.py, branch])`. Это лишний процесс и потеря in-process типов ошибок. Извлёк `create_branch(name)` из `new_branch.main()` и вызываю напрямую.

**Что сознательно НЕ сделано (см. issue #254):**
- **Вариант A (`gh issue develop`) → wontfix**: создаёт remote-ветку + issue-link (преждевременный write в origin, приоритет (3)), не чистит `[gone]` (#72), кириллицу всё равно надо слугифицировать самим — обёртка съела бы весь выигрыш.
- **`from scripts.new_branch import ...` → отвергнуто (architect BLOCKING)**: сломало бы CLI `python scripts/issue_branch.py <N>` при зелёных тестах. При script-path запуске `sys.path[0]` = `scripts/`, корень репо на `sys.path` не попадает (editable-install кладёт только `src/`) → `ModuleNotFoundError`. Пакетность `scripts/` (после #253) необходима, но **не достаточна**. Загрузку по абсолютному пути (`_branch_prefix` → `_new_branch_module`) сохранил — она иммунна к `sys.path`.

## Test plan

- `tests/test_issue_branch.py::TestDirectDelegation::test_main_delegates_to_create_branch_in_process` — новый: `main()` вызывает `create_branch` **в том же процессе** с точным `issue-254-<slug>` (первое покрытие оркестрации `main()`). RED до рефактора.
- `tests/test_new_branch.py::TestCreateBranchVisibility::test_dirty_tree_exits_nonzero` — §IV guard: извлечённый `create_branch` при грязном дереве даёт non-zero exit, не тихий return.
- Существующие slugify/build/fetch/_run/prune/guard — регресс, зелёные.
- **CLI-верификация** (PoC, который план изначально пропустил): воспроизвёл script-path `sys.path` (корень репо отсутствует) → загрузка резолвится, `create_branch` доступен, ветка не создаётся.
- `python scripts/ci_check.py` — all checks passed.

## Risk & Rollback

Низкий: поведение и CLI обоих скриптов неизменны, только устранён внутренний ре-спавн. Откат — revert одного коммита.

## Docs touched

Нет `.md` (CLI/поведение не меняются). Обновлён только устаревший docstring `test_new_branch.py` («scripts/ не пакет» — теперь ложь) на верную причину (absolute-path load), плюс новый docstring `_new_branch_module` объясняет sys.path-ловушку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
