### PR TITLE
Фильтр уведомлений kinozal по нежелательным жанрам + rename URLS → KINOZAL_URLS

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -87,7 +87,8 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.BOT_CHATID }}
           API_KEY: ${{ secrets.API_KEY }}
-          URLS: ${{ vars.URLS }}
+          KINOZAL_URLS: ${{ vars.KINOZAL_URLS }}
+          KINOZAL_EXCLUDED_GENRES: ${{ vars.KINOZAL_EXCLUDED_GENRES }}
           KINOZAL_USERNAME: ${{ secrets.KINOZAL_USERNAME }}
           KINOZAL_PASSWORD: ${{ secrets.KINOZAL_PASSWORD }}
 

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -291,12 +291,13 @@ next source slip back into the cascade.
 | Variable | Type | Purpose |
 |---|---|---|
 | `API_KEY` | secret | Kinozal API key |
-| `URLS` | var | Kinozal page URLs to scrape, формат `label\|url;...`; local fallback — env `KINOZAL_TOP_URL` (plain url). Если не задано ни то ни другое — pipeline логирует ошибку `no URLs configured`. `sources.json` `url`/`base_url` для скрейпинга **не читается** (только schema-placeholder), см. `kinozal_pipeline.py::_kinozal_urls` |
+| `KINOZAL_URLS` | var | Kinozal page URLs to scrape, формат `label\|url;...`; local fallback — env `KINOZAL_TOP_URL` (plain url). Если не задано ни то ни другое — pipeline логирует ошибку `no URLs configured`. Легаси-имя `URLS` **больше не читается** (clean rename, #263). `sources.json` `url`/`base_url` для скрейпинга **не читается** (только schema-placeholder), см. `kinozal_pipeline.py::_kinozal_urls` |
+| `KINOZAL_EXCLUDED_GENRES` | var | **Опционально.** `;`-разделённый denylist жанров (case-insensitive), напр. `Hidden objects`. Новый элемент, чей жанр (с details-страницы) в списке, **не** уведомляется, но сохраняется в Sheets (dedup). Пусто/не задано → фильтр выключен, details-страницы не запрашиваются (0 оверхеда). См. `kinozal_pipeline.py::_split_by_excluded_genre` (#263) |
 | `KINOZAL_USERNAME` | secret | **Опционально.** Логин аккаунта на зеркале `kinozal.guru` — включает автоматический fallback на зеркало при сбое `kinozal.tv` (см. блок ниже). Парный к `KINOZAL_PASSWORD`; **partial** (только один из двух) → WARNING + fallback отключён (не fail) |
 | `KINOZAL_PASSWORD` | secret | **Опционально.** Пароль аккаунта `kinozal.guru`. Парный к `KINOZAL_USERNAME` |
 
 > **Fallback на зеркало при недоступности `kinozal.tv` (#227):** primary —
-> анонимный `kinozal.tv` (`URLS` остаётся `.tv`, **переключать не нужно**). Если fetch какого-то
+> анонимный `kinozal.tv` (`KINOZAL_URLS` остаётся `.tv`, **переключать не нужно**). Если fetch какого-то
 > URL падает (напр. 522), пайплайн автоматически повторяет тот же топ на зеркале **`kinozal.guru`**
 > через авторизованную сессию. Логин **ленивый** — выполняется максимум раз за прогон и только при
 > первом срабатывании fallback, поэтому здоровый `.tv`-прогон не платит за логин и не требует кредов.

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -8,7 +8,7 @@ import re
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from curl_cffi.requests import Session as _MirrorSession
 
 from kinozal_scraper.generic_pipeline import (
@@ -55,15 +55,25 @@ def _excluded_genres() -> set[str]:
 def _parse_genre(details_html: str) -> str:
     """Read the `Жанр:` value off a kinozal details page (#263).
 
-    The field lives as `<b>Жанр:</b> <value>` inside the info block (verified by
-    PoC); the value may be multi-valued (comma-separated). Returns the raw value
-    string, or '' if the field is absent (caller treats '' as unknown → keep)."""
+    Real markup (verified against the live page): the value follows the
+    `<b>Жанр:</b>` label as tag-wrapped links/spans
+    (`<span class="lnks_tobrs">Hidden objects</span>`), terminated by a `<br>`,
+    and may be multi-valued (comma-separated). We collect the *visible text* of
+    the siblings up to the `<br>` — `str(sibling)` would serialize raw HTML for a
+    tag-wrapped value, and `next_sibling` alone is just the whitespace text node.
+    Returns '' if the field is absent (caller treats '' as unknown → keep)."""
     soup = BeautifulSoup(details_html, "html.parser")
-    for b in soup.find_all("b"):
-        if b.get_text(strip=True).startswith("Жанр"):
-            nxt = b.next_sibling
-            if nxt is not None:
-                return str(nxt).strip()
+    for label in soup.find_all("b"):
+        if not label.get_text(strip=True).startswith("Жанр"):
+            continue
+        parts: list[str] = []
+        for sib in label.next_siblings:
+            if getattr(sib, "name", None) in ("br", "b"):
+                break
+            text = sib.get_text(" ", strip=True) if isinstance(sib, Tag) else str(sib).strip()
+            if text:
+                parts.append(text)
+        return " ".join(parts).strip()
     return ""
 
 
@@ -324,6 +334,7 @@ def _split_by_excluded_genre(
     """
     kept: list[NormalizedItem] = []
     filtered: list[NormalizedItem] = []
+    unparsed: list[NormalizedItem] = []
     for item in items:
         try:
             genre = _parse_genre(fetcher.fetch_details(item.url))
@@ -336,10 +347,22 @@ def _split_by_excluded_genre(
             )
             kept.append(item)
             continue
-        if genre and _genre_excluded(genre, excluded):
+        if not genre:
+            # Fetched OK but no genre parsed — kept (fail-open). Tracked so a drifted
+            # `Жанр:` selector surfaces as a visible anomaly (§IV) instead of the
+            # filter silently becoming a no-op for every item.
+            unparsed.append(item)
+            kept.append(item)
+        elif _genre_excluded(genre, excluded):
             filtered.append(item)
         else:
             kept.append(item)
+    if unparsed:
+        logger.info(
+            "kinozal pipeline: %d item(s) fetched with no parseable genre (kept) — %s",
+            len(unparsed),
+            ", ".join(sorted(i.title for i in unparsed)),
+        )
     return kept, filtered
 
 

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -142,29 +142,26 @@ class Kinozal:
             )
         return cls(username, password)
 
-    def _fetch_with_failover(self, url: str) -> tuple[str, str]:
-        """(html, effective_origin): anonymous primary, authenticated mirror on
-        any primary failure. Shared by listing and details fetches so both make
-        one origin-vs-mirror decision (#247/#263)."""
+    def fetch_listing(self, url: str) -> tuple[str, str]:
+        """Return (html, effective_base_url): the HTML plus the origin that
+        actually served it (#247) — anonymous primary, authenticated mirror on
+        any primary failure. Primary success → the requested origin
+        (kinozal.tv); mirror fallback → kinozal.guru. The pipeline resolves the
+        listing's relative links/posters against this base, so a mirror-served
+        page yields .guru links (live for the logged-in user) instead of dead
+        .tv ones — reversing #227/#241's fixed canonical-origin choice.
+
+        `fetch_details` reuses this origin→mirror decision (#263)."""
         try:
             return fetch_html(url), _origin(url)
         except Exception as primary_exc:  # noqa: BLE001 — any primary-fetch failure falls back to the mirror
             return self._from_mirror(url, primary_exc), _origin(_mirror_url(url))
 
-    def fetch_listing(self, url: str) -> tuple[str, str]:
-        """Return (html, effective_base_url): the HTML plus the origin that
-        actually served it (#247). Primary success → the requested origin
-        (kinozal.tv); mirror fallback → kinozal.guru. The pipeline resolves the
-        listing's relative links/posters against this base, so a mirror-served
-        page yields .guru links (live for the logged-in user) instead of dead
-        .tv ones — reversing #227/#241's fixed canonical-origin choice."""
-        return self._fetch_with_failover(url)
-
     def fetch_details(self, url: str) -> str:
         """Fetch a details.php page for genre filtering (#263), sharing the
         listing's origin→mirror failover. Returns just the HTML — the `Жанр:`
         field is read from it, no base_url resolution needed."""
-        return self._fetch_with_failover(url)[0]
+        return self.fetch_listing(url)[0]
 
     def fetch_poster(self, url: str) -> bytes:
         """Download a poster, sharing the listing's origin→mirror failover (#241).

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+from bs4 import BeautifulSoup
 from curl_cffi.requests import Session as _MirrorSession
 
 from kinozal_scraper.generic_pipeline import (
@@ -28,16 +29,51 @@ logger = logging.getLogger(__name__)
 
 
 def _kinozal_urls() -> list[str]:
-    """Read Kinozal URLs from the existing URLS env variable (format: 'label|url;...').
+    """Read Kinozal URLs from the KINOZAL_URLS env variable (format: 'label|url;...').
 
-    Falls back to KINOZAL_TOP_URL if URLS is not set, so the runner works both
-    in production (URLS already configured) and in local testing.
+    Falls back to KINOZAL_TOP_URL (a single plain URL) for local testing. The
+    legacy name `URLS` is NOT read (clean rename, #263): a stale `URLS` no longer
+    silently masks a missing `KINOZAL_URLS`.
     """
-    urls_env = os.environ.get("URLS", "")
+    urls_env = os.environ.get("KINOZAL_URLS", "")
     if urls_env:
         return [pair.split("|")[1] for pair in urls_env.split(";") if "|" in pair]
     fallback = os.environ.get("KINOZAL_TOP_URL", "")
     return [fallback] if fallback else []
+
+
+def _excluded_genres() -> set[str]:
+    """Denylist of genres to suppress from notifications (#263).
+
+    Read from KINOZAL_EXCLUDED_GENRES (`;`-separated), normalized to lower/trim.
+    Empty/unset → empty set → the genre filter is off (no details fetch at all).
+    """
+    raw = os.environ.get("KINOZAL_EXCLUDED_GENRES", "")
+    return {g.strip().lower() for g in raw.split(";") if g.strip()}
+
+
+def _parse_genre(details_html: str) -> str:
+    """Read the `Жанр:` value off a kinozal details page (#263).
+
+    The field lives as `<b>Жанр:</b> <value>` inside the info block (verified by
+    PoC); the value may be multi-valued (comma-separated). Returns the raw value
+    string, or '' if the field is absent (caller treats '' as unknown → keep)."""
+    soup = BeautifulSoup(details_html, "html.parser")
+    for b in soup.find_all("b"):
+        if b.get_text(strip=True).startswith("Жанр"):
+            nxt = b.next_sibling
+            if nxt is not None:
+                return str(nxt).strip()
+    return ""
+
+
+def _genre_excluded(genre_raw: str, excluded: set[str]) -> bool:
+    """True if any comma-separated genre in `genre_raw` is in `excluded`.
+
+    Matching is case-insensitive and trimmed (both sides normalized). Empty
+    `excluded` → False."""
+    genres = {g.strip().lower() for g in genre_raw.split(",") if g.strip()}
+    return bool(genres & excluded)
 
 
 _ORIGIN_HOST = "kinozal.tv"
@@ -96,6 +132,15 @@ class Kinozal:
             )
         return cls(username, password)
 
+    def _fetch_with_failover(self, url: str) -> tuple[str, str]:
+        """(html, effective_origin): anonymous primary, authenticated mirror on
+        any primary failure. Shared by listing and details fetches so both make
+        one origin-vs-mirror decision (#247/#263)."""
+        try:
+            return fetch_html(url), _origin(url)
+        except Exception as primary_exc:  # noqa: BLE001 — any primary-fetch failure falls back to the mirror
+            return self._from_mirror(url, primary_exc), _origin(_mirror_url(url))
+
     def fetch_listing(self, url: str) -> tuple[str, str]:
         """Return (html, effective_base_url): the HTML plus the origin that
         actually served it (#247). Primary success → the requested origin
@@ -103,10 +148,13 @@ class Kinozal:
         listing's relative links/posters against this base, so a mirror-served
         page yields .guru links (live for the logged-in user) instead of dead
         .tv ones — reversing #227/#241's fixed canonical-origin choice."""
-        try:
-            return fetch_html(url), _origin(url)
-        except Exception as primary_exc:  # noqa: BLE001 — any primary-fetch failure falls back to the mirror
-            return self._from_mirror(url, primary_exc), _origin(_mirror_url(url))
+        return self._fetch_with_failover(url)
+
+    def fetch_details(self, url: str) -> str:
+        """Fetch a details.php page for genre filtering (#263), sharing the
+        listing's origin→mirror failover. Returns just the HTML — the `Жанр:`
+        field is read from it, no base_url resolution needed."""
+        return self._fetch_with_failover(url)[0]
 
     def fetch_poster(self, url: str) -> bytes:
         """Download a poster, sharing the listing's origin→mirror failover (#241).
@@ -264,6 +312,37 @@ def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
         return ""
 
 
+def _split_by_excluded_genre(
+    items: list[NormalizedItem], fetcher: Kinozal, excluded: set[str]
+) -> tuple[list[NormalizedItem], list[NormalizedItem]]:
+    """Partition new items into (kept, filtered) by their details-page genre (#263).
+
+    Fetches each item's details page (+1 HTTP/item — only reached when the
+    denylist is non-empty) and drops those whose genre ∈ excluded. A details
+    fetch failure fails OPEN: the item is KEPT with a WARNING — an unknown genre
+    must reach the user as a visible item, never be silently suppressed (§IV).
+    """
+    kept: list[NormalizedItem] = []
+    filtered: list[NormalizedItem] = []
+    for item in items:
+        try:
+            genre = _parse_genre(fetcher.fetch_details(item.url))
+        except Exception as exc:  # noqa: BLE001 — details-fetch degrade: unknown genre → keep + WARN, never silent-drop (§IV)
+            logger.warning(
+                "[%s] genre lookup failed for %r (%s) — keeping item (fail-open)",
+                item.source_id,
+                item.title,
+                exc,
+            )
+            kept.append(item)
+            continue
+        if genre and _genre_excluded(genre, excluded):
+            filtered.append(item)
+        else:
+            kept.append(item)
+    return kept, filtered
+
+
 def run_kinozal_pipeline(  # noqa: C901, PLR0912, PLR0915
     storage: Storage,
     notifier: Notifier,
@@ -286,14 +365,14 @@ def run_kinozal_pipeline(  # noqa: C901, PLR0912, PLR0915
 
     source_map = {s["id"]: s for s in kinozal_sources}
 
-    # URLs come from the existing URLS env variable (same format as legacy scraper).
+    # URLs come from the KINOZAL_URLS env variable (label|url;... format).
     # sources.json url field is only a schema placeholder / local fallback.
     urls = _kinozal_urls()
     if not urls:
-        logger.error("kinozal pipeline: no URLs configured (set URLS or KINOZAL_TOP_URL)")
+        logger.error("kinozal pipeline: no URLs configured (set KINOZAL_URLS or KINOZAL_TOP_URL)")
         for source in kinozal_sources:
             result = PipelineResult(source_id=source["id"])
-            result.errors.append("no URLs configured (set URLS or KINOZAL_TOP_URL)")
+            result.errors.append("no URLs configured (set KINOZAL_URLS or KINOZAL_TOP_URL)")
             results.append(result)
         return results
 
@@ -357,25 +436,45 @@ def run_kinozal_pipeline(  # noqa: C901, PLR0912, PLR0915
         logger.info("kinozal pipeline: no new items")
         return results
 
+    # Genre denylist (#263): drop items whose details-page genre ∈ excluded. The
+    # details fetch (+1 HTTP/item) only runs when the denylist is non-empty, so a
+    # healthy default (unset var) pays zero overhead. `filtered` items are NOT
+    # notified but ARE stored below (dedup) so they aren't re-fetched every run —
+    # a conscious terminal non-delivery, ≠ a failed delivery (Principle III retries
+    # only failures).
+    excluded = _excluded_genres()
+    if excluded:
+        kept, filtered = _split_by_excluded_genre(new_items, fetcher, excluded)
+        if filtered:
+            logger.info(
+                "kinozal pipeline: filtered %d item(s) by excluded genre: %s",
+                len(filtered),
+                ", ".join(sorted(i.title for i in filtered)),
+            )
+    else:
+        kept, filtered = new_items, []
+
     notifications: list[Notification] = []
-    for item in new_items:
+    for item in kept:
         item.trailer_url = enrich_with_trailer(item, youtube)
         template = source_map[item.source_id]["message_template"]
         notifications.append(build_notification(item, template))
 
-    # Persist only confirmed-delivered items (Principle III). Failed deliveries
-    # stay unstored so the next run retries them, and surface as a visible
-    # anomaly via result.errors + non-zero exit (Principle IV).
+    # Persist confirmed-delivered items PLUS genre-filtered ones (Principle III).
+    # Failed deliveries stay unstored so the next run retries them, and surface as
+    # a visible anomaly via result.errors + non-zero exit (Principle IV). The
+    # store-guard keys on `items_to_store` (not `sent`) so filtered items are
+    # persisted even when every new item was filtered and nothing was sent.
     sent, failed = notifier.send_items(notifications)
 
-    if sent:
-        sent_ids = {n.id for n in sent}
-        items_to_store = [i for i in new_items if i.dedupe_key in sent_ids]
+    sent_ids = {n.id for n in sent}
+    items_to_store = [i for i in kept if i.dedupe_key in sent_ids] + filtered
+    if items_to_store:
         storage.append_rows("movies", ROW_HEADERS, [i.to_row() for i in items_to_store])
 
     if failed:
         result_by_source = {r.source_id: r for r in results}
-        item_by_key = {i.dedupe_key: i for i in new_items}
+        item_by_key = {i.dedupe_key: i for i in kept}
         for notif in failed:
             # notif.id is always a new_item dedupe_key whose source has a result,
             # so both lookups must succeed — a KeyError here is a real bug.

--- a/tests/test_e2e_kinozal_titles.py
+++ b/tests/test_e2e_kinozal_titles.py
@@ -1,6 +1,6 @@
 """E2E: fetch real kinozal.tv and verify that titles are free of technical metadata.
 
-Uses URLS/KINOZAL_TOP_URL env var if set, falls back to the public top page.
+Uses KINOZAL_URLS/KINOZAL_TOP_URL env var if set, falls back to the public top page.
 
 Temporarily disabled: this test hits the live kinozal.tv top page, which is
 currently returning HTTP 520 (origin down), so it fails any unrelated PR's CI.

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import re
 import unittest
 import unittest.mock
 from typing import Any
@@ -218,32 +219,23 @@ class TestTitleYearMatches(unittest.TestCase):
 
 
 class TestKinozalUrls(unittest.TestCase):
-    def test_reads_existing_URLS_variable(self) -> None:
-        with unittest.mock.patch.dict(
-            os.environ,
-            {"URLS": "топ|https://kinozal.tv/top.php;новинки|https://kinozal.tv/new.php"},
-            clear=False,
-        ):
-            urls = _kinozal_urls()
-        self.assertEqual(urls, ["https://kinozal.tv/top.php", "https://kinozal.tv/new.php"])
-
     def test_falls_back_to_KINOZAL_TOP_URL(self) -> None:
         env = {"KINOZAL_TOP_URL": "https://kinozal.tv/top.php"}
         with unittest.mock.patch.dict(os.environ, env, clear=False):
-            os.environ.pop("URLS", None)
+            os.environ.pop("KINOZAL_URLS", None)
             urls = _kinozal_urls()
         self.assertEqual(urls, ["https://kinozal.tv/top.php"])
 
     def test_returns_empty_when_nothing_configured(self) -> None:
         with unittest.mock.patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("URLS", None)
+            os.environ.pop("KINOZAL_URLS", None)
             os.environ.pop("KINOZAL_TOP_URL", None)
             urls = _kinozal_urls()
         self.assertEqual(urls, [])
 
-    def test_URLS_takes_priority_over_KINOZAL_TOP_URL(self) -> None:
+    def test_KINOZAL_URLS_takes_priority_over_KINOZAL_TOP_URL(self) -> None:
         env = {
-            "URLS": "label|https://kinozal.tv/top.php",
+            "KINOZAL_URLS": "label|https://kinozal.tv/top.php",
             "KINOZAL_TOP_URL": "https://other.example.com",
         }
         with unittest.mock.patch.dict(os.environ, env, clear=False):
@@ -288,7 +280,7 @@ def _run(
     notifier: InMemoryNotifier | None = None,
     storage: InMemoryStorage | None = None,
 ) -> tuple[InMemoryStorage, InMemoryNotifier]:
-    """Run the real run_kinozal_pipeline with HTTP patched and URLS env set.
+    """Run the real run_kinozal_pipeline with HTTP patched and KINOZAL_URLS env set.
 
     This invokes production code directly so tests fail if the pipeline
     behaviour changes — no inline copy of the orchestration logic.
@@ -302,7 +294,7 @@ def _run(
         unittest.mock.patch("kinozal_scraper.kinozal_pipeline.fetch_html", return_value=html),
         unittest.mock.patch.dict(
             os.environ,
-            {"URLS": "top|https://test.example/top.php"},
+            {"KINOZAL_URLS": "top|https://test.example/top.php"},
             clear=False,
         ),
     ):
@@ -466,7 +458,7 @@ class TestPipelineFailureIsolation(unittest.TestCase):
         self.assertEqual(notifier.sent, [])
 
     def test_no_urls_configured_does_nothing(self) -> None:
-        """Pipeline early-exits when neither URLS nor KINOZAL_TOP_URL is set."""
+        """Pipeline early-exits when neither KINOZAL_URLS nor KINOZAL_TOP_URL is set."""
         storage = InMemoryStorage()
         notifier = InMemoryNotifier()
         with (
@@ -475,7 +467,7 @@ class TestPipelineFailureIsolation(unittest.TestCase):
             ),
             unittest.mock.patch.dict(os.environ, {}, clear=False),
         ):
-            os.environ.pop("URLS", None)
+            os.environ.pop("KINOZAL_URLS", None)
             os.environ.pop("KINOZAL_TOP_URL", None)
             run_kinozal_pipeline(storage, notifier, _FakeYoutube(), _SOURCES_CONFIG)
         self.assertEqual(storage.stored_rows("movies"), [])
@@ -491,7 +483,7 @@ class TestPipelineFailureIsolation(unittest.TestCase):
             ),
             unittest.mock.patch.dict(
                 os.environ,
-                {"URLS": "top|https://test.example/top.php"},
+                {"KINOZAL_URLS": "top|https://test.example/top.php"},
                 clear=False,
             ),
         ):
@@ -516,7 +508,7 @@ class TestKinozalPipelineExitCodeSurface(unittest.TestCase):
             ),
             unittest.mock.patch.dict(
                 os.environ,
-                {"URLS": "top|https://test.example/top.php"},
+                {"KINOZAL_URLS": "top|https://test.example/top.php"},
                 clear=False,
             ),
         ):
@@ -541,7 +533,7 @@ class TestKinozalPipelineExitCodeSurface(unittest.TestCase):
             ),
             unittest.mock.patch.dict(
                 os.environ,
-                {"URLS": "top|https://test.example/top.php"},
+                {"KINOZAL_URLS": "top|https://test.example/top.php"},
                 clear=False,
             ),
         ):
@@ -561,7 +553,7 @@ class TestKinozalPipelineExitCodeSurface(unittest.TestCase):
             ),
             unittest.mock.patch.dict(
                 os.environ,
-                {"URLS": "top|https://test.example/top.php"},
+                {"KINOZAL_URLS": "top|https://test.example/top.php"},
                 clear=False,
             ),
         ):
@@ -617,7 +609,7 @@ def _run_results(
         unittest.mock.patch("kinozal_scraper.kinozal_pipeline.fetch_html", return_value=html),
         unittest.mock.patch.dict(
             os.environ,
-            {"URLS": "top|https://test.example/top.php"},
+            {"KINOZAL_URLS": "top|https://test.example/top.php"},
             clear=False,
         ),
     ):
@@ -695,7 +687,7 @@ class TestPipelineAuth(unittest.TestCase):
     Failover and both-failed are visible (§IV); credentials are an optional
     backup, not a hard requirement."""
 
-    _URLS = {"URLS": "top|https://kinozal.tv/top.php?d=14"}
+    _URLS = {"KINOZAL_URLS": "top|https://kinozal.tv/top.php?d=14"}
 
     def _run_with_env(
         self, env: dict[str, str], urls: str | None = None
@@ -704,7 +696,7 @@ class TestPipelineAuth(unittest.TestCase):
         # `env` sets exactly the credentials each test wants to exercise.
         full = dict(self._URLS)
         if urls is not None:
-            full["URLS"] = urls
+            full["KINOZAL_URLS"] = urls
         full.update(env)
         storage = InMemoryStorage()
         notifier = InMemoryNotifier()
@@ -1019,7 +1011,7 @@ class TestLinkOriginFollowsHost(unittest.TestCase):
     _CREDS = {"KINOZAL_USERNAME": "u", "KINOZAL_PASSWORD": "p"}
 
     def _run(self, urls: str) -> InMemoryNotifier:
-        full = {"URLS": urls, **self._CREDS}
+        full = {"KINOZAL_URLS": urls, **self._CREDS}
         storage = InMemoryStorage()
         notifier = InMemoryNotifier()
         with unittest.mock.patch.dict(os.environ, full, clear=False):
@@ -1096,11 +1088,11 @@ def _details_html(genre: str) -> str:
 
 # Listing with two distinct items → two details pages keyed by id.
 _GENRE_LISTING = (
-    '<html><body>'
+    "<html><body>"
     '<a href="/details.php?id=1" title="Game A / RU / Hidden objects / 2024 / PC">'
     '<img src="/p1.jpg"></a>'
     '<a href="/details.php?id=2" title="Movie B / 2025 / BDRip"><img src="/p2.jpg"></a>'
-    '</body></html>'
+    "</body></html>"
 )
 _GENRE_BY_ID = {"1": "Hidden objects", "2": "драма"}
 
@@ -1179,7 +1171,6 @@ def _run_genre_filter(
         unittest.mock.patch("kinozal_scraper.kinozal_pipeline.fetch_html", side_effect=_fetch),
         unittest.mock.patch.dict(os.environ, env, clear=False),
     ):
-        os.environ.pop("URLS", None)
         os.environ.pop("KINOZAL_TOP_URL", None)
         if excluded is None:
             os.environ.pop("KINOZAL_EXCLUDED_GENRES", None)

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -1081,9 +1081,17 @@ class TestLinkOriginFollowsHost(unittest.TestCase):
 
 
 def _details_html(genre: str) -> str:
-    """Synthetic kinozal details page carrying a `Жанр:` field, matching the
-    real structure (`<h2>...<b>Жанр:</b> <value> ...</h2>`, verified by PoC)."""
-    return f"<html><body><h2><b>Жанр:</b> {genre}</h2></body></html>"
+    """Synthetic kinozal details page mirroring the REAL markup (verified against
+    the live page): the `Жанр:` value is tag-wrapped (`<span class="lnks_tobrs">`),
+    NOT a bare text node, sits after a whitespace node, and is terminated by <br>.
+    A parser reading `next_sibling`/`str()` naively would get '' or raw HTML here."""
+    return (
+        "<html><body><h2>"
+        "<b>Год выпуска:</b> 2024<br>"
+        f'<b>Жанр:</b> <span class="lnks_tobrs">{genre}</span><br>'
+        "<b>Разработчик:</b> X"
+        "</h2></body></html>"
+    )
 
 
 # Listing with two distinct items → two details pages keyed by id.
@@ -1100,8 +1108,26 @@ _GENRE_BY_ID = {"1": "Hidden objects", "2": "драма"}
 class TestParseGenre(unittest.TestCase):
     """`_parse_genre` reads the `Жанр:` value off a details page (pure)."""
 
-    def test_extracts_genre_from_details_html(self) -> None:
-        self.assertEqual(kp._parse_genre(_details_html("Hidden objects")), "Hidden objects")
+    def test_extracts_tag_wrapped_genre_as_plain_text(self) -> None:
+        # Real markup wraps the value in <span>; must return visible text, never
+        # the raw '<span ...>' HTML (would break denylist matching).
+        result = kp._parse_genre(_details_html("Hidden objects"))
+        self.assertEqual(result, "Hidden objects")
+        self.assertNotIn("<span", result)
+
+    def test_extracts_multivalue_genre(self) -> None:
+        # Multiple tag-wrapped genres separated by a comma text node.
+        html = (
+            "<html><body><h2><b>Жанр:</b> "
+            '<span class="lnks_tobrs">боевик</span>, '
+            '<span class="lnks_tobrs">триллер</span><br>'
+            "<b>Разработчик:</b> X</h2></body></html>"
+        )
+        parsed = kp._parse_genre(html)
+        self.assertIn("боевик", parsed)
+        self.assertIn("триллер", parsed)
+        # And the parsed value must be matchable by the denylist splitter.
+        self.assertTrue(kp._genre_excluded(parsed, {"триллер"}))
 
     def test_returns_empty_when_no_genre_field(self) -> None:
         self.assertEqual(kp._parse_genre("<html><body><h2>no genre here</h2></body></html>"), "")
@@ -1226,6 +1252,20 @@ class TestGenreFilter(unittest.TestCase):
             _run_genre_filter(excluded="Hidden objects")
         joined = "\n".join(cm.output)
         self.assertRegex(joined, r"(?i)filter.*1|1.*excluded genre")
+
+    def test_unparsed_genre_logged_but_item_kept(self) -> None:
+        # §IV: a successfully-fetched item with no parseable genre (e.g. the
+        # `Жанр:` selector drifted) is kept (fail-open) AND surfaced in the log,
+        # so a silent filter-wide no-op can't hide. Distinct from the fetch-error
+        # WARNING path — this is the successful-fetch-but-empty case.
+        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="INFO") as cm:
+            _, notifier, _ = _run_genre_filter(
+                excluded="Hidden objects", genre_by_id={"1": "", "2": "драма"}
+            )
+        self.assertEqual({n.id for n in notifier.sent}, {"Game A", "Movie B"})  # both kept
+        joined = "\n".join(cm.output)
+        self.assertRegex(joined, r"(?i)no parseable genre")
+        self.assertIn("Game A", joined)
 
 
 class TestKinozalFacade(unittest.TestCase):

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -3,6 +3,7 @@ import unittest
 import unittest.mock
 from typing import Any
 
+import kinozal_scraper.kinozal_pipeline as kp
 from kinozal_scraper.generic_pipeline import NormalizedItem, PipelineResult, extract_from_html
 from kinozal_scraper.kinozal_auth import KinozalLoginError
 from kinozal_scraper.kinozal_pipeline import (
@@ -248,6 +249,31 @@ class TestKinozalUrls(unittest.TestCase):
         with unittest.mock.patch.dict(os.environ, env, clear=False):
             urls = _kinozal_urls()
         self.assertEqual(urls, ["https://kinozal.tv/top.php"])
+
+    def test_reads_KINOZAL_URLS(self) -> None:
+        # After the URLS→KINOZAL_URLS rename (#263): the new variable is the one read.
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"KINOZAL_URLS": "топ|https://kinozal.tv/top.php;новинки|https://kinozal.tv/new.php"},
+            clear=False,
+        ):
+            os.environ.pop("URLS", None)
+            os.environ.pop("KINOZAL_TOP_URL", None)
+            urls = _kinozal_urls()
+        self.assertEqual(urls, ["https://kinozal.tv/top.php", "https://kinozal.tv/new.php"])
+
+    def test_old_URLS_not_read(self) -> None:
+        # Clean cut (#263): the legacy URLS name is no longer a fallback. With only
+        # URLS set and no KINOZAL_URLS/KINOZAL_TOP_URL, the pipeline sees no URLs.
+        with unittest.mock.patch.dict(
+            os.environ,
+            {"URLS": "топ|https://kinozal.tv/top.php"},
+            clear=False,
+        ):
+            os.environ.pop("KINOZAL_URLS", None)
+            os.environ.pop("KINOZAL_TOP_URL", None)
+            urls = _kinozal_urls()
+        self.assertEqual(urls, [])
 
 
 # ── run_kinozal_pipeline (direct invocation, no helper duplicating prod logic) ─
@@ -1057,6 +1083,181 @@ class TestLinkOriginFollowsHost(unittest.TestCase):
         beta = next(n for n in notifier.sent if "Beta Film" in n.text)
         self.assertIn("kinozal.tv/details.php?id=1", alpha.text)  # served by primary
         self.assertIn("kinozal.guru/details.php?id=2", beta.text)  # served by mirror
+
+
+# ── genre exclusion filter (issue #263) ───────────────────────────────────────
+
+
+def _details_html(genre: str) -> str:
+    """Synthetic kinozal details page carrying a `Жанр:` field, matching the
+    real structure (`<h2>...<b>Жанр:</b> <value> ...</h2>`, verified by PoC)."""
+    return f"<html><body><h2><b>Жанр:</b> {genre}</h2></body></html>"
+
+
+# Listing with two distinct items → two details pages keyed by id.
+_GENRE_LISTING = (
+    '<html><body>'
+    '<a href="/details.php?id=1" title="Game A / RU / Hidden objects / 2024 / PC">'
+    '<img src="/p1.jpg"></a>'
+    '<a href="/details.php?id=2" title="Movie B / 2025 / BDRip"><img src="/p2.jpg"></a>'
+    '</body></html>'
+)
+_GENRE_BY_ID = {"1": "Hidden objects", "2": "драма"}
+
+
+class TestParseGenre(unittest.TestCase):
+    """`_parse_genre` reads the `Жанр:` value off a details page (pure)."""
+
+    def test_extracts_genre_from_details_html(self) -> None:
+        self.assertEqual(kp._parse_genre(_details_html("Hidden objects")), "Hidden objects")
+
+    def test_returns_empty_when_no_genre_field(self) -> None:
+        self.assertEqual(kp._parse_genre("<html><body><h2>no genre here</h2></body></html>"), "")
+
+
+class TestGenreMatching(unittest.TestCase):
+    """`_genre_excluded` splits a (possibly multi-valued) genre string and tests
+    membership against the denylist, case-insensitively and trimmed (pure)."""
+
+    def test_multivalue_comma_any_match(self) -> None:
+        self.assertTrue(kp._genre_excluded("боевик, триллер", {"триллер"}))
+
+    def test_case_insensitive_trim(self) -> None:
+        self.assertTrue(kp._genre_excluded(" Hidden Objects ", {"hidden objects"}))
+
+    def test_not_excluded(self) -> None:
+        self.assertFalse(kp._genre_excluded("драма", {"hidden objects"}))
+
+
+class TestExcludedGenresEnv(unittest.TestCase):
+    """`_excluded_genres` parses the `KINOZAL_EXCLUDED_GENRES` env into a
+    normalized set (`;`-separated, lower/trim); unset → empty set."""
+
+    def test_parses_semicolon_list(self) -> None:
+        with unittest.mock.patch.dict(
+            os.environ, {"KINOZAL_EXCLUDED_GENRES": "Hidden objects; Эротика"}, clear=False
+        ):
+            self.assertEqual(kp._excluded_genres(), {"hidden objects", "эротика"})
+
+    def test_empty_when_unset(self) -> None:
+        with unittest.mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("KINOZAL_EXCLUDED_GENRES", None)
+            self.assertEqual(kp._excluded_genres(), set())
+
+
+def _run_genre_filter(
+    excluded: str | None,
+    listing: str = _GENRE_LISTING,
+    genre_by_id: dict[str, str] | None = None,
+    details_error: bool = False,
+) -> tuple[InMemoryStorage, InMemoryNotifier, list[str]]:
+    """Drive run_kinozal_pipeline with the genre filter, injecting at the HTTP
+    boundary (`fetch_html`) like the #247 origin tests — NOT by mocking the
+    Kinozal facade (§II). `fetch_html` dispatches by URL: a details.php URL
+    returns that item's genre page (and is recorded), anything else the listing.
+    Returns (storage, notifier, list-of-details-URLs-fetched).
+    """
+    genre_by_id = genre_by_id if genre_by_id is not None else _GENRE_BY_ID
+    details_calls: list[str] = []
+
+    def _fetch(url: str) -> str:
+        if "details.php" in url:
+            details_calls.append(url)
+            if details_error:
+                raise RuntimeError("details fetch boom")
+            match = re.search(r"id=(\d+)", url)
+            gid = match.group(1) if match else ""
+            return _details_html(genre_by_id.get(gid, "unknown"))
+        return listing
+
+    storage = InMemoryStorage()
+    notifier = InMemoryNotifier()
+    env = {"KINOZAL_URLS": "top|https://kinozal.tv/top.php"}
+    if excluded is not None:
+        env["KINOZAL_EXCLUDED_GENRES"] = excluded
+    with (
+        unittest.mock.patch("kinozal_scraper.kinozal_pipeline.fetch_html", side_effect=_fetch),
+        unittest.mock.patch.dict(os.environ, env, clear=False),
+    ):
+        os.environ.pop("URLS", None)
+        os.environ.pop("KINOZAL_TOP_URL", None)
+        if excluded is None:
+            os.environ.pop("KINOZAL_EXCLUDED_GENRES", None)
+        run_kinozal_pipeline(storage, notifier, _FakeYoutube(), _SOURCES_CONFIG)
+    return storage, notifier, details_calls
+
+
+class TestGenreFilter(unittest.TestCase):
+    """#263: new items whose details-page genre ∈ KINOZAL_EXCLUDED_GENRES are
+    dropped from notifications but still stored (dedup), fetch degrades visibly."""
+
+    def test_excluded_genre_item_not_notified(self) -> None:
+        _, notifier, _ = _run_genre_filter(excluded="Hidden objects")
+        sent_ids = {n.id for n in notifier.sent}
+        self.assertNotIn("Game A", sent_ids)  # Hidden objects → filtered
+        self.assertIn("Movie B", sent_ids)  # драма → kept
+
+    def test_non_excluded_item_notified(self) -> None:
+        _, notifier, _ = _run_genre_filter(excluded="Hidden objects")
+        self.assertIn("Movie B", {n.id for n in notifier.sent})
+
+    def test_filtered_item_is_stored(self) -> None:
+        storage, notifier, _ = _run_genre_filter(excluded="Hidden objects")
+        stored = {row[0] for row in storage.stored_rows("movies")}
+        self.assertIn("Game A", stored)  # stored so it isn't re-fetched next run
+        self.assertNotIn("Game A", {n.id for n in notifier.sent})  # but not notified
+
+    def test_all_filtered_still_stored(self) -> None:
+        # Every new item excluded → kept empty, sent empty; filtered must STILL be
+        # stored (store-guard keys on items_to_store, not on sent) and not crash.
+        storage, notifier, _ = _run_genre_filter(excluded="Hidden objects; драма")
+        self.assertEqual(notifier.sent, [])
+        stored = {row[0] for row in storage.stored_rows("movies")}
+        self.assertEqual(stored, {"Game A", "Movie B"})
+
+    def test_details_fetch_failure_fails_open_and_warns(self) -> None:
+        # §IV: unknown genre (fetch failed) must not silently drop the item —
+        # it ships (fail-open) with a WARNING tripwire.
+        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="WARNING") as cm:
+            _, notifier, _ = _run_genre_filter(excluded="Hidden objects", details_error=True)
+        self.assertEqual({n.id for n in notifier.sent}, {"Game A", "Movie B"})
+        self.assertTrue(any("genre" in line.lower() for line in cm.output), cm.output)
+
+    def test_no_details_fetch_when_denylist_empty(self) -> None:
+        # Zero runtime overhead on the healthy default: empty denylist → no
+        # details fetch at all. (Guard; passes trivially pre-implementation.)
+        _, notifier, details_calls = _run_genre_filter(excluded=None)
+        self.assertEqual(details_calls, [])
+        self.assertEqual({n.id for n in notifier.sent}, {"Game A", "Movie B"})
+
+    def test_filter_count_logged(self) -> None:
+        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="INFO") as cm:
+            _run_genre_filter(excluded="Hidden objects")
+        joined = "\n".join(cm.output)
+        self.assertRegex(joined, r"(?i)filter.*1|1.*excluded genre")
+
+
+class TestKinozalFacade(unittest.TestCase):
+    """`Kinozal.fetch_details` shares the listing origin→mirror failover (#263),
+    injected at the HTTP boundary like the #247 fetch_listing tests (§II)."""
+
+    def test_fetch_details_falls_back_to_mirror(self) -> None:
+        from kinozal_scraper.kinozal_pipeline import Kinozal
+
+        sentinel = unittest.mock.Mock()
+        mirror_html = _details_html("Hidden objects")
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_html",
+                side_effect=RuntimeError("HTTP Error 522"),
+            ),
+            unittest.mock.patch("kinozal_scraper.kinozal_pipeline.login", return_value=sentinel),
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_authenticated", return_value=mirror_html
+            ),
+        ):
+            html = Kinozal("u", "p").fetch_details("https://kinozal.tv/details.php?id=1")
+        self.assertEqual(html, mirror_html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Фильтр уведомлений kinozal по жанрам + rename `URLS`→`KINOZAL_URLS`. Новый элемент, чей жанр (с details-страницы, поле `Жанр:`) ∈ `KINOZAL_EXCLUDED_GENRES` (`;`-разделённый denylist, case-insensitive), **не** уведомляется, но сохраняется в Sheets (dedup) — чтобы не перезапрашивать details каждый прогон. Details-fetch (+1 HTTP/элемент) выполняется **только** когда denylist непуст (пустой → 0 оверхеда). Совпало с issue `## Implementation outline`; отклонений нет.

Closes #263

## Test plan

Зеркалит issue `## Test plan` (все прогнаны):
- [x] `TestParseGenre` / `TestGenreMatching` / `TestExcludedGenresEnv` — pure-функции парса/матча/env
- [x] `TestKinozalUrls::test_reads_KINOZAL_URLS` + `test_old_URLS_not_read` — rename без fallback
- [x] `TestGenreFilter::*` — excluded не уведомляется, non-excluded уведомляется, filtered хранится, **все отсеяны → всё равно хранятся (store-guard по items_to_store)**, fail-open+WARNING при сбое details, denylist пуст → 0 details-fetch, §IV лог счётчика
- [x] `TestKinozalFacade::test_fetch_details_falls_back_to_mirror` — общий origin→mirror failover
- [x] `python scripts/ci_check.py` — green локально (ruff/pytest/mypy/pip-audit/import-linter)
- [ ] CI на PR — green

## Risk & Rollback

- **Blast-radius:** kinozal-пайплайн (крон `run-script.yml`). Details-fetch добавляет +1 HTTP на новый элемент **только при непустом denylist**; при сбое — fail-open (§IV), доставка не блокируется. Не задевает Gemini/Steam/events/summarizer.
- **Rollback:** чистый `git revert` PR. Уже отправленные Telegram-сообщения необратимы (как обычно), но фильтр только *подавляет* отправку — revert просто вернёт прежнее поведение.
- **⚠️ Координация переменных (сделано аддитивно до мержа):** `vars.KINOZAL_URLS` (копия `URLS`) и `vars.KINOZAL_EXCLUDED_GENRES=Hidden objects` уже созданы — красного окна нет. **После мержа** удалить легаси `vars.URLS` (`gh variable delete URLS`) как cleanup.
- **Мониторинг:** ближайший крон-ран `run-script.yml` — проверить лог `filtered N item(s) by excluded genre` и что доставка идёт.

## Docs touched

- `docs/architecture/ci.md` — env-таблица: `URLS`→`KINOZAL_URLS`, новая строка `KINOZAL_EXCLUDED_GENRES`, заметка про mirror.
- `.github/workflows/run-script.yml` — проброс `KINOZAL_URLS` + `KINOZAL_EXCLUDED_GENRES`.
- `tests/test_e2e_kinozal_titles.py` — docstring rename.
