### PR TITLE
fix(kinozal): resolve fastpic viewer pages to signed image posters

### DIFF
--- a/src/kinozal_scraper/http_fetch.py
+++ b/src/kinozal_scraper/http_fetch.py
@@ -9,6 +9,26 @@ from __future__ import annotations
 from curl_cffi import requests
 
 
+class NotAnImageError(Exception):
+    """A 200 response that is HTML, not the image we asked for (issue #265).
+
+    Anti-hotlink hosts (e.g. fastpic.org) answer a bare image URL with a 200
+    `text/html` viewer page instead of the JPEG. `raise_for_status()` passes it,
+    so without a content-type check `fetch_bytes` would hand ~300 KB of HTML back
+    as "poster bytes" (→ Telegram `sendPhoto` 400 → poster silently dropped).
+
+    Carries `url`, the actual `content_type`, and the already-downloaded `body`
+    so a resolver can extract the direct signed image link from the viewer page
+    WITHOUT a second GET of the same 300 KB page (runtime tokens/traffic; keeps
+    the signed-link `expires` window tight)."""
+
+    def __init__(self, url: str, content_type: str, body: bytes) -> None:
+        super().__init__(f"{url} returned {content_type!r}, not an image")
+        self.url = url
+        self.content_type = content_type
+        self.body = body
+
+
 def fetch_html(url: str) -> str:
     resp = requests.get(url, impersonate="chrome", timeout=30)
     resp.raise_for_status()
@@ -22,7 +42,16 @@ def fetch_bytes(url: str) -> bytes:
     #225, same gating as #217) return 200 instead of 403. We download posters
     our side and upload them to Telegram as multipart, because `sendPhoto`-by-URL
     is fetched by Telegram's own servers, which Cloudflare blocks.
+
+    Guards against the #265 anti-hotlink trap: a 200 `text/html` response is NOT
+    image bytes → `NotAnImageError`. This is a **blocklist** (`text/html`), not an
+    `image/*` allowlist — posters live on a long tail of uploader hosts that may
+    serve exotic content-types, and blocking the one observed garbage class
+    (viewer page) avoids false-positives on a valid image with an odd type.
     """
     resp = requests.get(url, impersonate="chrome", timeout=30)
     resp.raise_for_status()
+    content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+    if content_type == "text/html":
+        raise NotAnImageError(url, content_type, resp.content)
     return resp.content

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -19,7 +19,7 @@ from kinozal_scraper.generic_pipeline import (
     build_notification,
     extract_from_html,
 )
-from kinozal_scraper.http_fetch import fetch_bytes, fetch_html
+from kinozal_scraper.http_fetch import NotAnImageError, fetch_bytes, fetch_html
 from kinozal_scraper.kinozal_auth import fetch_authenticated, login
 from kinozal_scraper.pipeline_config import load_sources_config
 from kinozal_scraper.sheets_storage import Storage
@@ -89,6 +89,35 @@ def _genre_excluded(genre_raw: str, excluded: set[str]) -> bool:
 _ORIGIN_HOST = "kinozal.tv"
 _MIRROR_HOST = "kinozal.guru"
 _KINOZAL_HOSTS = frozenset({_ORIGIN_HOST, _MIRROR_HOST})
+_FASTPIC_HOST = "fastpic.org"
+
+
+def _is_fastpic(host: str) -> bool:
+    """True for the fastpic anti-hotlink host and its numbered CDN subdomains
+    (e.g. `i126.fastpic.org`) — the hosts that serve a viewer page for a bare
+    image URL (#265)."""
+    return host == _FASTPIC_HOST or host.endswith("." + _FASTPIC_HOST)
+
+
+def _extract_direct_image_url(viewer_html: str, requested_url: str) -> str:
+    """From a fastpic anti-hotlink viewer page, return the signed full-size
+    `<img src>` — the one whose base path (URL sans query) equals `requested_url`
+    (#265). The real image sits behind a signed query (`?md5=&expires=`) on the
+    SAME path we requested; `og:image` on the page points at a *thumbnail* on a
+    different path, so we match on the base path, never just "the first <img>".
+    Returns '' when no `<img>` matches (unresolvable → caller degrades visibly)."""
+    requested_base = urlunsplit(urlsplit(requested_url)._replace(query="", fragment=""))
+    soup = BeautifulSoup(viewer_html, "html.parser")
+    for img in soup.find_all("img"):
+        src = img.get("src")
+        # bs4 types `.get` as str | AttributeValueList | None; a real src="" attr
+        # is a single string. Skip the missing/multi-valued cases outright.
+        if not isinstance(src, str) or not src:
+            continue
+        base = urlunsplit(urlsplit(src)._replace(query="", fragment=""))
+        if base == requested_base:
+            return src
+    return ""
 
 
 def _mirror_url(url: str) -> str:
@@ -172,9 +201,26 @@ class Kinozal:
         propagates and the notifier degrades to text + WARNING (§IV). A
         primary-on-.guru failure isn't re-swapped to the same host. The mirror
         poster fetch is anonymous — no _ensure_login, so one dead-origin poster
-        on an otherwise-healthy run pays no login cost."""
+        on an otherwise-healthy run pays no login cost.
+
+        For a fastpic anti-hotlink viewer page (`NotAnImageError`, #265) the
+        signed full-size link is resolved from the exception body (the already-
+        downloaded viewer HTML — no second GET) and fetched. **Invariant:** this
+        returns the BYTES downloaded within this call, never the signed URL — a
+        future refactor must not hoist resolve out and revive `expires` staleness
+        (the window is milliseconds today: the notifier downloads the poster once,
+        before its retry loop)."""
         try:
             return fetch_bytes(url)
+        except NotAnImageError as viewer_exc:
+            host = urlsplit(url).netloc
+            if not _is_fastpic(host):
+                raise  # only fastpic serves the viewer-page trap we can resolve
+            direct = _extract_direct_image_url(viewer_exc.body.decode("utf-8", "replace"), url)
+            if not direct:
+                raise  # unresolvable → propagate so the notifier degrades visibly (§IV)
+            logger.info("[kinozal] fastpic viewer resolved to signed image for %s", url)
+            return fetch_bytes(direct)
         except Exception as primary_exc:  # noqa: BLE001 — mirror-retry for kinozal hosts, else propagate to §IV degrade
             host = urlsplit(url).netloc
             if host not in _KINOZAL_HOSTS or host == _MIRROR_HOST:

--- a/tests/test_http_fetch.py
+++ b/tests/test_http_fetch.py
@@ -77,11 +77,11 @@ class TestFetchBytes(unittest.TestCase):
         mock_resp = unittest.mock.Mock()
         mock_resp.content = body
         mock_resp.headers = {"content-type": "text/html"}
-        with unittest.mock.patch(
-            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
+        with (
+            unittest.mock.patch("kinozal_scraper.http_fetch.requests.get", return_value=mock_resp),
+            self.assertRaises(NotAnImageError) as ctx,
         ):
-            with self.assertRaises(NotAnImageError) as ctx:
-                fetch_bytes(url)
+            fetch_bytes(url)
         err = ctx.exception
         self.assertEqual(err.url, url)
         self.assertEqual(err.content_type, "text/html")
@@ -91,9 +91,7 @@ class TestFetchBytes(unittest.TestCase):
         mock_resp = unittest.mock.Mock()
         mock_resp.content = b"\xff\xd8\xff\xe0JPEG"
         mock_resp.headers = {"content-type": "image/jpeg"}
-        with unittest.mock.patch(
-            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
-        ):
+        with unittest.mock.patch("kinozal_scraper.http_fetch.requests.get", return_value=mock_resp):
             result = fetch_bytes("https://example.com/poster.jpg")
         self.assertEqual(result, b"\xff\xd8\xff\xe0JPEG")
 
@@ -103,11 +101,11 @@ class TestFetchBytes(unittest.TestCase):
         mock_resp = unittest.mock.Mock()
         mock_resp.content = b"<html></html>"
         mock_resp.headers = {"content-type": "text/html; charset=UTF-8"}
-        with unittest.mock.patch(
-            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
+        with (
+            unittest.mock.patch("kinozal_scraper.http_fetch.requests.get", return_value=mock_resp),
+            self.assertRaises(NotAnImageError),
         ):
-            with self.assertRaises(NotAnImageError):
-                fetch_bytes("https://i126.fastpic.org/big/x.jpg")
+            fetch_bytes("https://i126.fastpic.org/big/x.jpg")
 
 
 if __name__ == "__main__":

--- a/tests/test_http_fetch.py
+++ b/tests/test_http_fetch.py
@@ -1,7 +1,7 @@
 import unittest
 import unittest.mock
 
-from kinozal_scraper.http_fetch import fetch_bytes, fetch_html
+from kinozal_scraper.http_fetch import NotAnImageError, fetch_bytes, fetch_html
 
 
 class TestFetchHtml(unittest.TestCase):
@@ -47,6 +47,7 @@ class TestFetchBytes(unittest.TestCase):
     def test_passes_impersonate_chrome_and_returns_content(self) -> None:
         mock_resp = unittest.mock.Mock()
         mock_resp.content = b"\x89PNG\r\n"
+        mock_resp.headers = {"content-type": "image/png"}
         with unittest.mock.patch(
             "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
         ) as mget:
@@ -65,6 +66,48 @@ class TestFetchBytes(unittest.TestCase):
             self.assertRaises(RuntimeError),
         ):
             fetch_bytes("https://example.com/poster.jpg")
+
+    def test_raises_not_an_image_on_text_html(self) -> None:
+        # #265: a fastpic anti-hotlink viewer page returns 200 text/html (~300 KB).
+        # fetch_bytes must NOT hand that HTML back as "poster bytes" — it raises a
+        # typed NotAnImageError carrying url + content-type + the already-downloaded
+        # body (so the resolver reuses it without a second GET).
+        body = b"<html><title>FastPic viewer</title></html>"
+        url = "https://i126.fastpic.org/big/x.jpg"
+        mock_resp = unittest.mock.Mock()
+        mock_resp.content = body
+        mock_resp.headers = {"content-type": "text/html"}
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
+        ):
+            with self.assertRaises(NotAnImageError) as ctx:
+                fetch_bytes(url)
+        err = ctx.exception
+        self.assertEqual(err.url, url)
+        self.assertEqual(err.content_type, "text/html")
+        self.assertEqual(err.body, body)
+
+    def test_returns_content_for_image_content_type(self) -> None:
+        mock_resp = unittest.mock.Mock()
+        mock_resp.content = b"\xff\xd8\xff\xe0JPEG"
+        mock_resp.headers = {"content-type": "image/jpeg"}
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
+        ):
+            result = fetch_bytes("https://example.com/poster.jpg")
+        self.assertEqual(result, b"\xff\xd8\xff\xe0JPEG")
+
+    def test_content_type_match_is_case_and_param_insensitive(self) -> None:
+        # "text/html; charset=UTF-8" must normalize (strip params, lowercase) to
+        # text/html and raise — a real server sends the charset param.
+        mock_resp = unittest.mock.Mock()
+        mock_resp.content = b"<html></html>"
+        mock_resp.headers = {"content-type": "text/html; charset=UTF-8"}
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
+        ):
+            with self.assertRaises(NotAnImageError):
+                fetch_bytes("https://i126.fastpic.org/big/x.jpg")
 
 
 if __name__ == "__main__":

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -1268,6 +1268,91 @@ class TestGenreFilter(unittest.TestCase):
         self.assertIn("Game A", joined)
 
 
+# ── fastpic viewer resolve (issue #265) ───────────────────────────────────────
+
+_FASTPIC_URL = "https://i126.fastpic.org/big/2026/0205/00/67b3a8e599df986493824b9ed4fbbf00.jpg"
+_FASTPIC_SIGNED = _FASTPIC_URL + "?md5=Kv8Hlp-9IPlUe1YuQpFH-g&expires=1782979200"
+# Real fastpic anti-hotlink page: og:image points at a thumbnail (different path),
+# the full-size image is a signed <img> at the same base path as the requested URL.
+_FASTPIC_VIEWER_HTML = (
+    "<html><head>"
+    '<meta property="og:image" content="https://i126.fastpic.org/thumb/2026/0205/00/x.jpeg">'
+    "</head><body>"
+    f'<img src="{_FASTPIC_SIGNED}" class="image">'
+    "</body></html>"
+)
+
+
+class TestExtractDirectImageUrl(unittest.TestCase):
+    """`_extract_direct_image_url` pulls the signed full-size <img> out of a fastpic
+    viewer page — the one whose base path (URL sans query) equals the requested URL,
+    NOT the og:image thumbnail (different path). Pure helper, tested directly (§I)."""
+
+    def test_extracts_signed_fastpic_link(self) -> None:
+        result = kp._extract_direct_image_url(_FASTPIC_VIEWER_HTML, _FASTPIC_URL)
+        self.assertEqual(result, _FASTPIC_SIGNED)
+
+    def test_returns_empty_when_no_matching_img(self) -> None:
+        # Viewer page whose only <img> is a thumbnail on a different path → no
+        # signed full-size link resolvable → "".
+        html = (
+            "<html><body>"
+            '<img src="https://i126.fastpic.org/thumb/2026/0205/00/x.jpeg">'
+            "</body></html>"
+        )
+        self.assertEqual(kp._extract_direct_image_url(html, _FASTPIC_URL), "")
+
+
+class TestFetchPosterFastpic(unittest.TestCase):
+    """`Kinozal.fetch_poster` resolves a fastpic viewer page to its signed image
+    without a second GET of the 300 KB page — it reuses the body carried on
+    NotAnImageError. Injection stays on the HTTP boundary; the stub raises a REAL
+    NotAnImageError (not a re-invented content-type check) per §II."""
+
+    def _kinozal(self) -> Any:
+        from kinozal_scraper.kinozal_pipeline import Kinozal
+
+        return Kinozal("u", "p")
+
+    def test_fetch_poster_resolves_fastpic_viewer_to_signed_image(self) -> None:
+        from kinozal_scraper.http_fetch import NotAnImageError
+
+        calls: list[str] = []
+
+        def _fetch(url: str) -> bytes:
+            calls.append(url)
+            if url == _FASTPIC_URL:
+                raise NotAnImageError(url, "text/html", _FASTPIC_VIEWER_HTML.encode("utf-8"))
+            return b"\xff\xd8\xff\xe0JPEG"
+
+        with unittest.mock.patch(
+            "kinozal_scraper.kinozal_pipeline.fetch_bytes", side_effect=_fetch
+        ):
+            data = self._kinozal().fetch_poster(_FASTPIC_URL)
+        self.assertEqual(data, b"\xff\xd8\xff\xe0JPEG")
+        # second fetch hit the SIGNED link, resolved from the exception body (no
+        # re-GET of the viewer page).
+        self.assertEqual(calls, [_FASTPIC_URL, _FASTPIC_SIGNED])
+
+    def test_fetch_poster_fastpic_unresolvable_propagates(self) -> None:
+        from kinozal_scraper.http_fetch import NotAnImageError
+
+        # Viewer body with no matching full-size <img> → resolve returns "" →
+        # NotAnImageError propagates so the notifier degrades visibly (§IV).
+        viewer = b"<html><body><img src='https://i126.fastpic.org/thumb/x.jpeg'></body></html>"
+
+        def _fetch(url: str) -> bytes:
+            raise NotAnImageError(url, "text/html", viewer)
+
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.kinozal_pipeline.fetch_bytes", side_effect=_fetch
+            ),
+            self.assertRaises(NotAnImageError),
+        ):
+            self._kinozal().fetch_poster(_FASTPIC_URL)
+
+
 class TestKinozalFacade(unittest.TestCase):
     """`Kinozal.fetch_details` shares the listing origin→mirror failover (#263),
     injected at the HTTP boundary like the #247 fetch_listing tests (§II)."""

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -1345,9 +1345,7 @@ class TestFetchPosterFastpic(unittest.TestCase):
             raise NotAnImageError(url, "text/html", viewer)
 
         with (
-            unittest.mock.patch(
-                "kinozal_scraper.kinozal_pipeline.fetch_bytes", side_effect=_fetch
-            ),
+            unittest.mock.patch("kinozal_scraper.kinozal_pipeline.fetch_bytes", side_effect=_fetch),
             self.assertRaises(NotAnImageError),
         ):
             self._kinozal().fetch_poster(_FASTPIC_URL)


### PR DESCRIPTION
## Summary

Постеры раздач с fastpic.org приходили без картинки: `fetch_bytes` отдавал 200 `text/html` (анти-хотлинк viewer-страница ~300 КБ) как «байты постера» → Telegram `sendPhoto` 400 → постер дропался в текст.

Теперь `fetch_bytes` отклоняет `text/html`-ответ как `NotAnImageError` (blocklist, несёт url+content-type+тело), а `Kinozal.fetch_poster` резолвит из тела исключения подписанную `/big/…jpg?md5=&expires=` ссылку (без второго GET) и качает её. Неразрешимый постер пробрасывает `NotAnImageError` — нотифаер деградирует видимо (§IV: WARNING+текст).

Closes #265

Divergence: совпало с issue `## Implementation outline`. Единственное добавление сверх плана — `isinstance(src, str)`-гард в `_extract_direct_image_url` (bs4 `.get` типизирован как `str | AttributeValueList | None`; нужно для прохождения mypy-гейта).

## Test plan

Зеркалит issue `## Test plan`, все прогнаны:

- [x] `tests/test_http_fetch.py` — `text/html` → `NotAnImageError`; `image/*` → `.content`; case/param-insensitive нормализация content-type
- [x] `tests/test_kinozal_pipeline.py::TestExtractDirectImageUrl` — резолв подписанной ссылки по совпадению base path; `""` при отсутствии совпадения
- [x] `tests/test_kinozal_pipeline.py::TestFetchPosterFastpic` — viewer→signed резолв без второго GET; unresolvable → `NotAnImageError` пробрасывается
- [x] `python scripts/ci_check.py` — green локально (486 passed, ruff/mypy/import-linter/pip-audit clean)
- [ ] CI на PR — green

## Risk & Rollback

- Blast-radius: `fetch_bytes` — общий транспорт (постеры всех пайплайнов); теперь бросает `NotAnImageError` на `text/html`. Оба вызывающих (`fetch_poster`, notifier `_send_one`) уже обёрнуты в try/except → деградация в текст, не краш. Blocklist `text/html` (не allowlist) выбран, чтобы не отломать валидные постеры на экзотичных content-type.
- Rollback: чистый `git revert`, необратимых эффектов нет.
- Мониторинг: ближайший крон-ран `run-script.yml` — постеры fastpic-раздач должны доходить полноразмерными; в логах `fastpic viewer resolved to signed image`.

## Docs touched

none — behaviour unchanged в env/CI; контракт постер-fetch в docs не описан (зеркалит issue `## Docs to update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)