### PR TITLE
docs(ci): no-go on pre-commit/tox migration (#255)

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -22,6 +22,54 @@ a check in the registry without updating `ci.yml` fails
 Pre-push hook: `.githooks/pre-push` runs `ci_check.py` automatically.
 Activate: `git config core.hooksPath .githooks`
 
+> **Disambiguation:** this section's title "Local pre-commit" names the
+> pre-commit *moment* (the git-hook that runs before a push), **not** the
+> [`pre-commit`](https://pre-commit.com) framework — which this repo
+> deliberately does **not** use (next block).
+
+### `pre-commit`/`tox` consciously not adopted (#255)
+
+The `CHECKS` registry looks like a hand-rolled task-runner, so «why not the
+off-the-shelf [`pre-commit`](https://pre-commit.com) framework, or `tox`?» is a
+fair recurring question. Evaluated go/no-go in #255 → **no-go**, for a single
+root reason plus supporting ones (genre mirrors the vulture drop below):
+
+- **Root reason — `pre-commit` re-introduces the #153 drift class.** Every hook
+  under `pre-commit` pins its tool version via `rev:` in
+  `.pre-commit-config.yaml` and runs it in an **isolated venv**. That is a
+  *parallel* source of each tool's version, separate from `requirements-dev.txt`
+  (today `python -m ruff`/`mypy` run the single lockfile-pinned version). So
+  `pre-commit` systemically forks the very version-drift class that the registry
+  eliminated (#153). `mypy` is the sharp illustration: its isolated venv can't
+  see project deps, forcing an `additional_dependencies:` list — a hand-copied
+  duplicate of the dependency set outside `requirements.txt`.
+- **Half the checks aren't file-linters.** `requirements` (pin/`.in` drift) and
+  `imports` (import-linter via its Python API — the console script is
+  unreliable-on-PATH on Windows + the #109 `subprocess stdout=None` pitfall,
+  #234) are custom logic. Under `pre-commit` they'd stay scripts wrapped in
+  `local` hooks — zero gain, same Windows-PATH exposure for `imports`.
+- **The drift problem is already solved, cheaper.** The registry is the single
+  source of truth and `tests/test_ci_check.py::TestStepParity` guards
+  registry ↔ `ci.yml` parity — no new dependency, ~185 lines, and it houses the
+  non-file-linter gates uniformly.
+- **A *partial* migration is strictly worse.** file-linters → `pre-commit`,
+  gates stay scripts ⇒ two overlapping systems and a **three-way** parity
+  (`pre-commit` config ↔ registry ↔ `ci.yml`) whose third edge is **unguarded**
+  until someone writes a new parity test — a net increase in surface, the
+  opposite of the win.
+- **No clean partial-win survives the drift cost.** (a) staged-only speed is
+  marginal — `pytest`/`mypy`/`imports`/`pip-audit` are whole-project by nature;
+  (b) contributor onboarding — `pre-commit install` merely replaces the one
+  `git config core.hooksPath .githooks` line with its own install step (net
+  wash).
+- **`tox`/`nox` solve a problem we don't have.** They run a Python-**version
+  matrix**; this project is pinned to a single 3.12. Clear no.
+
+**Revisit trigger (wait-for-pain, not permanent dismissal):** flip to a partial
+`pre-commit` (file-linters only) *iff* real contributor pain from manual
+hook-version management appears; adopt `tox`/`nox` *iff* a genuine multi-version
+Python matrix becomes a requirement.
+
 ## CI workflow (`ci.yml`)
 
 Triggers: `pull_request` (covers every PR branch) + `push` to `main` only


### PR DESCRIPTION
## Summary

Discussion-first go/no-go (#255): решение **no-go** — оставить самописный реестр `CHECKS` в `scripts/ci_check.py`, НЕ мигрировать на фреймворк `pre-commit` или `tox`. Фиксирую решение doc-note'ом в `docs/architecture/ci.md` (жанр vulture-прецедента #235). Кода в `src/`/`scripts/` не трогал — behaviour не меняется.

Корневой довод: `pre-commit` пинит версию каждого инструмента через `rev:` в изолированном venv → параллельный источник истины к `requirements-dev.txt`, реинтродукция drift-класса #153, который реестр уже убрал (mypy `additional_dependencies` — острая иллюстрация). Половина гейтов (`requirements`, `imports`) — не файловые линтеры, остались бы скриптами; partial-миграция даёт негарджённую трёхстороннюю parity. `tox`/`nox` решают Python-version matrix, которого у pinned-3.12 проекта нет.

Divergence: совпало с issue `## Implementation outline` (no-go был вероятным исходом; architect-reviewer подтвердил аргументацию). Добавлен named revisit-trigger (wait-for-pain) и дизамбигуация заголовка «Local pre-commit» (git-hook-момент) от инструмента `pre-commit`.

Closes #255

## Test plan

Zero production/test-code change — documentation-only (§I(b), Test plan issue: тестов нет by design).

- [x] `python scripts/ci_check.py` — green локально (486 passed, 3 skipped; pre-push повторил — green)
- [ ] CI на PR — green

## Risk & Rollback

Low risk, revert-safe. Blast-radius: один `.md` (`docs/architecture/ci.md`), рантайм/крон-пайплайн/Sheets/Telegram/Gemini не затронуты. Rollback: чистый `git revert`, необратимых эффектов нет. Мониторинг: не требуется (docs-only, prod-поведение неизменно).

## Docs touched

- `docs/architecture/ci.md` — блок «`pre-commit`/`tox` consciously not adopted (#255)» + дизамбигуация заголовка. Зеркалит issue `## Docs to update`.
