### PR TITLE
feat(ci): ruff ARG001/ARG002/SLF001 unused-arg / private-access ratchet

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -221,6 +221,44 @@ caught **strictly harder** by `test_package_importable.py` (17 hard-coded
 import-linter. Keeping a bespoke no-op mini-gate would be the very velcro this
 change removes.
 
+### Unused-arg / private-access ratchet (lint, #236)
+
+The `lint` check also enforces three ruff rules with a *mixed* signal, triaged
+per-hit before enabling (110 existing hits, zero real dead params in `src/`):
+
+- `ARG001` — unused **function** argument;
+- `ARG002` — unused **method** argument;
+- `SLF001` — private-member access (`obj._x` where `obj` is not `self`/`cls`).
+
+Like the complexity/dead-code ratchets, ruff has no native baseline, so the
+value is **forward**: new `src/` code with a dead param or cross-class private
+access fails CI. Two silencing mechanisms, deliberately different, and this is
+the distinction the guard test pins:
+
+- **`tests/**` is a *categorical* exemption** (`per-file-ignores`
+  `"tests/**" = […, ARG001, ARG002, SLF001]`): white-box tests legitimately
+  reach into private members (§II mandates calling internal helpers directly)
+  and carry mock signatures whose params are dictated by the mocked callable,
+  not by usage. This is **unlike `ERA001`**, where tests are *not* exempt
+  (commented-out code is dead regardless of file role) — so the surface pattern
+  "tests always get a per-file-ignore" must **not** be cargo-culted from here.
+- **Individual false positives in `src/` get a per-site `# noqa`.** The two
+  hits are Protocol-conformance stubs (`NullEnricher.enrich`'s `item`,
+  `InMemoryStorage.append_rows`'s `headers`) whose param is required by the
+  interface but unused by that one implementation. A per-site noqa is the escape
+  hatch for a *genuine* FP — never for a real detector hit (that would train the
+  hatch on a non-exception, §IV).
+
+The two `SLF001` src hits were **not** noqa'd: `RotatingGeminiEnricher` reached
+into a sibling `GeminiEnricher._model_name` across the class boundary — a real
+§II leak, not noise. It was root-caused (§V) with a public `model_name`
+property, so `SLF001` has **zero** surviving src hits. `ARG003`/`004`/`005`
+(classmethod/staticmethod/lambda unused args) stay unselected — a conscious
+defer (#236 Out of scope), not a silent gap. `tests/test_ruff_arg_slf_rules.py`
+is an anti-drift guard (mirrors the docstring/complexity/dead-code guards): it
+pins the three codes in the effective select, out of global `ignore`, and not
+neutralised for any `src`/`scripts` path via `per-file-ignores`.
+
 ## Claude review workflow (`claude-review.yml`)
 
 Triggers: every `pull_request: opened/synchronize`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,13 @@ select = [
     "D100",     # missing docstring in public module
     "D104",     # missing docstring in public package (__init__.py)
     "D419",     # empty/whitespace-only docstring
+    # Unused-arg / private-access ratchet (#236). Forward guard on src: new dead
+    # params / cross-class private access fails CI. tests/** is categorically
+    # exempt below (white-box §II access + mock signatures); src false positives
+    # get a per-site noqa. See docs/architecture/ci.md.
+    "ARG001",   # unused-function-argument
+    "ARG002",   # unused-method-argument
+    "SLF001",   # private-member-access
 ]
 ignore = [
     "E501",
@@ -55,8 +62,11 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 # Tests were never docstring-checked (check_headers scanned src/ only); keep
-# them out of the D100/D104/D419 gate (#253).
-"tests/**" = ["D100", "D104", "D419"]
+# them out of the D100/D104/D419 gate (#253). ARG001/ARG002/SLF001 (#236) are a
+# categorical exemption too: white-box tests legitimately access private members
+# (§II) and carry mock signatures whose params are dictated by the interface,
+# not by usage — unlike ERA001, tests are NOT exempt there.
+"tests/**" = ["D100", "D104", "D419", "ARG001", "ARG002", "SLF001"]
 
 [tool.ruff.lint.mccabe]
 # Align C901 with PLR0912's default branch threshold (12) rather than tuning to

--- a/src/kinozal_scraper/gemini_enricher.py
+++ b/src/kinozal_scraper/gemini_enricher.py
@@ -114,7 +114,8 @@ class Enricher(Protocol):
 class NullEnricher:
     """No-op — for tests and when GOOGLE_API_KEY is absent."""
 
-    def enrich(self, item: NormalizedItem, enrich_config: dict[str, Any]) -> str:
+    def enrich(self, item: NormalizedItem, enrich_config: dict[str, Any]) -> str:  # noqa: ARG002
+        # `item` is unused here but required by the Enricher Protocol signature.
         result: str = enrich_config.get("on_error", "")
         return result
 
@@ -124,6 +125,15 @@ class GeminiEnricher:
 
     def __init__(self, model_name: str) -> None:
         self._model_name = model_name
+
+    @property
+    def model_name(self) -> str:
+        """Public read-only view of the backing model name.
+
+        Lets a coordinator (RotatingGeminiEnricher) name the model in logs
+        without reaching into `_model_name` across the class boundary (§II).
+        """
+        return self._model_name
 
     def enrich(self, item: NormalizedItem, enrich_config: dict[str, Any]) -> str:
         prompt_template = enrich_config["prompt"]
@@ -303,7 +313,7 @@ class RotatingGeminiEnricher:
                     return self._enrichers[self._current].enrich(item, enrich_config)
                 except (QuotaExhausted, ModelUnavailable, TryNextModel) as exc:
                     prev_idx = self._current
-                    prev = self._enrichers[prev_idx]._model_name
+                    prev = self._enrichers[prev_idx].model_name
                     if isinstance(exc, ModelUnavailable):
                         self._dead.add(prev_idx)
                         saw_recoverable_failure = True
@@ -328,7 +338,7 @@ class RotatingGeminiEnricher:
                             "model %s %s, trying %s",
                             prev,
                             kind,
-                            self._enrichers[preview]._model_name,
+                            self._enrichers[preview].model_name,
                         )
                     last_exc = exc
 

--- a/src/kinozal_scraper/sheets_storage.py
+++ b/src/kinozal_scraper/sheets_storage.py
@@ -83,7 +83,9 @@ class InMemoryStorage:
     def get_existing_keys(self, tab_name: str) -> set[str]:
         return set(self._keys[tab_name])
 
-    def append_rows(self, tab_name: str, headers: list[str], rows: list[list[Any]]) -> None:
+    def append_rows(self, tab_name: str, headers: list[str], rows: list[list[Any]]) -> None:  # noqa: ARG002
+        # `headers` is unused by the in-memory double but required by the Storage
+        # Protocol signature (the real SheetsStorage.append_rows does use it).
         for row in rows:
             self._rows[tab_name].append(row)
             if row:

--- a/tests/test_gemini_enricher.py
+++ b/tests/test_gemini_enricher.py
@@ -504,11 +504,18 @@ class TestRotatingGeminiEnricherModelUnavailable(unittest.TestCase):
         rotator._enrichers[0].enrich = fail_a  # type: ignore[assignment]
         rotator._enrichers[1].enrich = ok_b  # type: ignore[assignment]
 
-        for i in range(5):
-            self.assertEqual(rotator.enrich(_item(str(i)), _ENRICH_CFG), "from-b")
+        with self.assertLogs("kinozal_scraper.gemini_enricher", level="WARNING") as captured:
+            for i in range(5):
+                self.assertEqual(rotator.enrich(_item(str(i)), _ENRICH_CFG), "from-b")
 
         self.assertEqual(a_calls, 1, "dead model must not be retried for every item")
         self.assertEqual(b_calls, 5)
+        # The rotation warning names both the failed and the next model by their
+        # public `model_name` — pins the cross-class read that replaced the
+        # `._model_name` private access (#236).
+        rotation_log = "\n".join(captured.output)
+        self.assertIn("model-a", rotation_log)
+        self.assertIn("model-b", rotation_log)
 
     @unittest.mock.patch("kinozal_scraper.gemini_enricher.time.sleep")
     def test_all_models_unavailable_raises_quota_exhausted(self, mock_sleep: Any) -> None:

--- a/tests/test_ruff_arg_slf_rules.py
+++ b/tests/test_ruff_arg_slf_rules.py
@@ -1,0 +1,96 @@
+"""Anti-drift guard for the unused-arg / private-access ruff rules (#236).
+
+Three rules with a *mixed* signal were triaged and enabled: `ARG001`
+(unused-function-argument), `ARG002` (unused-method-argument) and `SLF001`
+(private-member-access). The 110 existing hits split into two categories that
+demand *different* silencing mechanisms, and this guard pins the distinction so
+a future agent cannot quietly collapse it:
+
+- **`tests/**` is a categorical exemption** (blanket `per-file-ignores`): tests
+  legitimately reach into private members (§II mandates calling internal
+  helpers directly in white-box tests) and carry mock signatures whose params
+  are dictated by the mocked callable, not by usage. This is *unlike* `ERA001`,
+  where tests are NOT exempt (commented-out code is dead regardless of file
+  role) — so the surface pattern "tests always get a per-file-ignore" is wrong
+  and must not be cargo-culted from here.
+- **Individual false positives inside in-scope `src/` files** get a per-site
+  `# noqa` (the two Protocol-conformance stubs whose param is required by the
+  interface but unused by that one implementation). A per-site noqa is the
+  escape hatch for a *genuine* FP — never for a real detector hit (that would
+  train the hatch on a non-exception, §IV). The two `SLF001` src hits were a
+  *real* §II leak and were root-caused (public `model_name` property), not
+  noqa'd — so `SLF001` has zero surviving src hits.
+
+This guard asserts the rules stay *active*: present in the effective select,
+not globally ignored, and not neutralised for any `src`/`scripts` path via
+`per-file-ignores` (the `tests/**` ignore is legitimate). Mirrors
+`test_ruff_docstring_rule.py` (#253) / `test_complexity_ratchet.py` (#233) /
+`test_ruff_dead_code_rule.py` (#235) — it pins *enforcement*, not mere
+declaration, so a future agent cannot quietly drop the gate through any disable
+vector. It deliberately does not re-run ruff green — that is redundant with the
+live `check_lint` gate (testing.md "when a test is not worth writing").
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+_REPO = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO / "pyproject.toml"
+
+# The triaged rules (#236).
+_ARG_SLF_CODES = {"ARG001", "ARG002", "SLF001"}
+# Representative source paths the gate MUST keep covering — a per-file-ignore
+# that silences one of these codes for any of these guts the gate (#236 threat).
+_PROTECTED_PATHS = (
+    "src/kinozal_scraper/__init__.py",
+    "src/kinozal_scraper/gemini_enricher.py",
+    "src/kinozal_scraper/sheets_storage.py",
+    "scripts/ci_check.py",
+)
+
+
+def _lint_config() -> dict[str, Any]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return cast("dict[str, Any]", data["tool"]["ruff"]["lint"])
+
+
+class TestRuffArgSlfRules:
+    def test_arg_slf_rules_active(self) -> None:
+        lint = _lint_config()
+
+        # (a) present in effective select (select ∪ extend-select).
+        selected = set(lint.get("select", [])) | set(lint.get("extend-select", []))
+        assert selected >= _ARG_SLF_CODES, (
+            "unused-arg / private-access codes must be in ruff select (#236 gate); "
+            f"missing: {_ARG_SLF_CODES - selected}"
+        )
+
+        # (b) not neutralised via global ignore.
+        ignored = set(lint.get("ignore", []))
+        assert not (_ARG_SLF_CODES & ignored), (
+            "unused-arg / private-access codes must not appear in ruff `ignore` "
+            f"(silently disables the #236 gate): {_ARG_SLF_CODES & ignored}"
+        )
+
+        # (c) not neutralised for a protected src/scripts path via
+        # per-file-ignores. Matched by real path coverage (fnmatch), not a
+        # literal "tests/" check — the tests/** ignore is a legitimate
+        # categorical exemption, but an ignore whose glob also catches a
+        # src/scripts file is a leak.
+        per_file: dict[str, list[str]] = lint.get("per-file-ignores", {})
+        leaks: dict[str, dict[str, list[str]]] = {}
+        for pattern, codes in per_file.items():
+            disabled = _ARG_SLF_CODES & set(codes)
+            if not disabled:
+                continue
+            hit = [p for p in _PROTECTED_PATHS if fnmatch.fnmatch(p, pattern)]
+            if hit:
+                leaks[pattern] = {"disables": sorted(disabled), "covers": hit}
+        assert not leaks, (
+            "per-file-ignores must not disable unused-arg / private-access codes "
+            f"for src/scripts paths (silently guts the #236 gate): {leaks}"
+        )


### PR DESCRIPTION
## Summary

Включает три ruff-правила со смешанным сигналом как форвардный ratchet: `ARG001`/`ARG002` (unused args) + `SLF001` (private-member access). Ценность — на будущий боевой код: новый мёртвый параметр или доступ к приватному чужого класса в `src/` краснит CI. Closes #236.

Совпало с issue `## Implementation outline`. Единственный «сюрприз» уже был учтён в плане после architect-review: 2 хита `SLF001` в `src/` — не FP, а реальная §II-протечка (`RotatingGeminiEnricher` читал `GeminiEnricher._model_name` через границу класса), поэтому устранены root-cause (публичное `model_name`-property), а не заглушены noqa.

Триаж 110 хитов:
- **106 в `tests/`** → категориальный `per-file-ignores` (white-box доступ к приватному §II + сигнатуры моков; в отличие от `ERA001` тесты тут исключение осознанно).
- **2 src `ARG002`** (Protocol-conformance стабы `NullEnricher.enrich`/`InMemoryStorage.append_rows`) → per-site `# noqa` с причиной.
- **2 src `SLF001`** → root-cause фикс, `SLF001` в src = 0.
- `ARG003`/`004`/`005` — осознанный defer (Out of scope).

## Test plan

- [x] `tests/test_ruff_arg_slf_rules.py::TestRuffArgSlfRules::test_arg_slf_rules_active` — anti-drift guard (mirror `test_ruff_docstring_rule.py`): коды в effective select, не в global `ignore`, не заглушены per-file-ignore для `src`/`scripts`. RED до правки `select` → GREEN после.
- [x] `SLF001` root-cause свап (`._model_name` → `.model_name`) покрыт ассерцией на текст WARNING ротации в `tests/test_gemini_enricher.py::TestRotatingGeminiEnricherModelUnavailable::test_dead_model_skipped_on_subsequent_items` (warning называет обе модели через публичное `model_name`) — добавлена по claude-review (прежняя ссылка на `assertLogs` указывала на несвязанные build-default сообщения).
- [x] `python scripts/ci_check.py` — green локально (ruff format+lint+pytest+mypy+pip-audit+lockfile+import-linter).
- [ ] CI на PR — green

## Risk & Rollback

- **Blast-radius:** изолировано. Config-flip (ruff select/ignore) + 1 публичное property на `GeminiEnricher` + 2 комментария-noqa + guard-тест + doc. Рантайм-поведение боевого кода не меняется (`.model_name` читает то же значение тем же способом); крон-пайплайн / Sheets-дедуп / Telegram-доставка / Gemini не затронуты.
- **Rollback:** чистый `git revert` PR, необратимых эффектов нет.
- **Мониторинг:** ничего сверх обычного — ближайший крон-ран `run-script.yml` должен пройти как раньше.

