### PR TITLE
refactor(github_trending): распил run_github_trending_pipeline (PLR0915=68 → helpers), снять noqa

### DIFF
--- a/src/kinozal_scraper/github_trending_pipeline.py
+++ b/src/kinozal_scraper/github_trending_pipeline.py
@@ -89,7 +89,125 @@ def _enrich_with_stars_today(html: str, items: list[NormalizedItem]) -> None:
         item.raw["stars_today"] = by_href.get(key, "")
 
 
-def run_github_trending_pipeline(  # noqa: C901, PLR0912, PLR0915
+def _warn_on_drift(source_id: str, items: list[NormalizedItem]) -> None:
+    """Surface empty metric/description as WARNINGs so page-layout drift reaches
+    the operator instead of silently shipping blank fields (§IV)."""
+    for item in items:
+        if not item.metric:
+            logger.warning(
+                "[%s] item '%s' has empty metric — page layout may have drifted",
+                source_id,
+                item.dedupe_key,
+            )
+        if not item.description:
+            logger.warning(
+                "[%s] item '%s' has empty description",
+                source_id,
+                item.dedupe_key,
+            )
+
+
+def _enrich_new_items(
+    enricher: Enricher,
+    new_items: list[NormalizedItem],
+    enrich_config: dict[str, Any],
+    source_id: str,
+) -> None:
+    """Enrich each new item in place; on QuotaExhausted stamp the fallback on
+    the current item and every remaining one, then stop (mutates the shared
+    NormalizedItem objects, so the caller sees the results)."""
+    field: str = enrich_config["field"]
+    # Empty `on_error` would blank the summary line in Telegram
+    # instead of surfacing the failure — use the visible marker
+    # so the operator sees a tripwire (#128, Principle IV).
+    fallback: str = enrich_config.get("on_error") or FALLBACK_MARKER
+    enriched, skipped = 0, 0
+    for item in new_items:
+        try:
+            item.raw[field] = enricher.enrich(item, enrich_config)
+            enriched += 1
+        except QuotaExhausted:
+            item.raw[field] = fallback
+            skipped += 1
+            for remaining in new_items[new_items.index(item) + 1 :]:
+                remaining.raw[field] = fallback
+                skipped += 1
+            break
+    if skipped:
+        logger.warning(
+            "[%s] enrichment quota exhausted: %d/%d enriched, %d skipped",
+            source_id,
+            enriched,
+            enriched + skipped,
+            skipped,
+        )
+    elif enriched:
+        logger.info("[%s] enriched %d items", source_id, enriched)
+
+
+def _process_trending_source(
+    source: dict[str, Any],
+    storage: Storage,
+    notifier: Notifier,
+    enricher: Enricher | None,
+) -> PipelineResult | None:
+    """Run one source end-to-end. Returns its PipelineResult, or None for the
+    no-url silent-skip (the source produces no result entry — behaviour
+    preserved byte-for-byte from the pre-split inline `continue`)."""
+    url: str = source.get("url", "")
+    if not url:
+        logger.warning("[%s] no URL configured", source["id"])
+        return None  # None = no-url silent-skip, preserved from pre-refactor
+
+    result = PipelineResult(source_id=source["id"])
+    try:
+        html_text = fetch_html(url)
+    except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
+        logger.exception("[%s] fetch failed: %s", source["id"], exc)
+        result.errors.append(f"fetch failed: {exc}")
+        return result
+
+    extracted = extract_from_html(html_text, source)
+    if not extracted.items and extracted.errors:
+        logger.error("[%s] extraction errors: %s", source["id"], extracted.errors)
+        result.errors.extend(extracted.errors)
+        return result
+
+    items = _normalize_items(extracted.items)
+    _enrich_with_stars_today(html_text, items)
+    _warn_on_drift(source["id"], items)
+
+    result.items = items
+
+    sheet_tab: str = source["sheet_tab"]
+    existing = storage.get_existing_keys(sheet_tab)
+    new_items = [i for i in items if i.dedupe_key not in existing]
+    if not new_items:
+        logger.info("[%s] no new items", source["id"])
+        return result
+
+    enrich_config = source.get("enrich")
+    if enrich_config and enricher is not None:
+        _enrich_new_items(enricher, new_items, enrich_config, source["id"])
+
+    template: str = source["message_template"]
+    notifications = [build_notification(item, template) for item in new_items]
+    sent, failed = notifier.send_items(notifications)
+
+    if sent:
+        sent_ids = {n.id for n in sent}
+        items_to_store = [i for i in new_items if i.dedupe_key in sent_ids]
+        storage.append_rows(sheet_tab, ROW_HEADERS, [i.to_row() for i in items_to_store])
+
+    if failed:
+        message = f"{len(failed)} notification(s) failed, will retry next run"
+        logger.error("[%s] %s", source["id"], message)
+        result.errors.append(message)
+    logger.info("[%s] sent %d notification(s)", source["id"], len(sent))
+    return result
+
+
+def run_github_trending_pipeline(
     storage: Storage,
     notifier: Notifier,
     enricher: Enricher | None = None,
@@ -103,98 +221,9 @@ def run_github_trending_pipeline(  # noqa: C901, PLR0912, PLR0915
         return results
 
     for source in trending_sources:
-        url: str = source.get("url", "")
-        if not url:
-            logger.warning("[%s] no URL configured", source["id"])
-            continue
-
-        result = PipelineResult(source_id=source["id"])
-        try:
-            html_text = fetch_html(url)
-        except Exception as exc:  # noqa: BLE001 — per-source isolation: logged + surfaced via result.errors
-            logger.exception("[%s] fetch failed: %s", source["id"], exc)
-            result.errors.append(f"fetch failed: {exc}")
+        result = _process_trending_source(source, storage, notifier, enricher)
+        if result is not None:  # None = no-url silent-skip, preserved from pre-refactor
             results.append(result)
-            continue
-
-        extracted = extract_from_html(html_text, source)
-        if not extracted.items and extracted.errors:
-            logger.error("[%s] extraction errors: %s", source["id"], extracted.errors)
-            result.errors.extend(extracted.errors)
-            results.append(result)
-            continue
-
-        items = _normalize_items(extracted.items)
-        _enrich_with_stars_today(html_text, items)
-        for item in items:
-            if not item.metric:
-                logger.warning(
-                    "[%s] item '%s' has empty metric — page layout may have drifted",
-                    source["id"],
-                    item.dedupe_key,
-                )
-            if not item.description:
-                logger.warning(
-                    "[%s] item '%s' has empty description",
-                    source["id"],
-                    item.dedupe_key,
-                )
-
-        result.items = items
-
-        sheet_tab: str = source["sheet_tab"]
-        existing = storage.get_existing_keys(sheet_tab)
-        new_items = [i for i in items if i.dedupe_key not in existing]
-        if not new_items:
-            logger.info("[%s] no new items", source["id"])
-            results.append(result)
-            continue
-
-        enrich_config = source.get("enrich")
-        if enrich_config and enricher is not None:
-            field: str = enrich_config["field"]
-            # Empty `on_error` would blank the summary line in Telegram
-            # instead of surfacing the failure — use the visible marker
-            # so the operator sees a tripwire (#128, Principle IV).
-            fallback: str = enrich_config.get("on_error") or FALLBACK_MARKER
-            enriched, skipped = 0, 0
-            for item in new_items:
-                try:
-                    item.raw[field] = enricher.enrich(item, enrich_config)
-                    enriched += 1
-                except QuotaExhausted:
-                    item.raw[field] = fallback
-                    skipped += 1
-                    for remaining in new_items[new_items.index(item) + 1 :]:
-                        remaining.raw[field] = fallback
-                        skipped += 1
-                    break
-            if skipped:
-                logger.warning(
-                    "[%s] enrichment quota exhausted: %d/%d enriched, %d skipped",
-                    source["id"],
-                    enriched,
-                    enriched + skipped,
-                    skipped,
-                )
-            elif enriched:
-                logger.info("[%s] enriched %d items", source["id"], enriched)
-
-        template: str = source["message_template"]
-        notifications = [build_notification(item, template) for item in new_items]
-        sent, failed = notifier.send_items(notifications)
-
-        if sent:
-            sent_ids = {n.id for n in sent}
-            items_to_store = [i for i in new_items if i.dedupe_key in sent_ids]
-            storage.append_rows(sheet_tab, ROW_HEADERS, [i.to_row() for i in items_to_store])
-
-        if failed:
-            message = f"{len(failed)} notification(s) failed, will retry next run"
-            logger.error("[%s] %s", source["id"], message)
-            result.errors.append(message)
-        logger.info("[%s] sent %d notification(s)", source["id"], len(sent))
-        results.append(result)
 
     return results
 

--- a/tests/test_github_trending_pipeline.py
+++ b/tests/test_github_trending_pipeline.py
@@ -377,16 +377,16 @@ class TestPipelineMechanics(unittest.TestCase):
         }
         storage = InMemoryStorage()
         notifier = InMemoryNotifier()
-        with unittest.mock.patch(
-            "kinozal_scraper.github_trending_pipeline.fetch_html",
-            return_value=_fixture_html(),
-        ):
-            with self.assertLogs(
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.github_trending_pipeline.fetch_html",
+                return_value=_fixture_html(),
+            ),
+            self.assertLogs(
                 "kinozal_scraper.github_trending_pipeline", level="WARNING"
-            ) as captured:
-                results = run_github_trending_pipeline(
-                    storage, notifier, sources_config=config
-                )
+            ) as captured,
+        ):
+            results = run_github_trending_pipeline(storage, notifier, sources_config=config)
 
         self.assertEqual(results, [])
         self.assertTrue(any("no URL configured" in line for line in captured.output))

--- a/tests/test_github_trending_pipeline.py
+++ b/tests/test_github_trending_pipeline.py
@@ -345,6 +345,54 @@ class TestPipelineMechanics(unittest.TestCase):
         self.assertFalse(results[0].ok)
         self.assertTrue(any("notification(s) failed" in err for err in results[0].errors))
 
+    def test_fetch_failure_recorded_in_result_errors(self) -> None:
+        # fetch-fail branch: fetch raises → the source's result stays in
+        # `results` with a "fetch failed" error and not-ok (#271 guard: the
+        # refactor rewrites this branch's exit from `append+continue` to
+        # `return result`, and it had zero coverage before).
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+        with unittest.mock.patch(
+            "kinozal_scraper.github_trending_pipeline.fetch_html",
+            side_effect=Exception("boom"),
+        ):
+            results = run_github_trending_pipeline(
+                storage, notifier, sources_config=_SOURCES_CONFIG
+            )
+
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].ok)
+        self.assertTrue(any("fetch failed" in err for err in results[0].errors))
+        self.assertEqual(storage.stored_rows("github_projects"), [])
+        self.assertEqual(notifier.sent, [])
+
+    def test_no_url_source_skipped_and_absent_from_results(self) -> None:
+        # no-url branch: an enabled source with empty url is silently skipped —
+        # a WARNING is logged and the source produces NO result entry (#271
+        # guard: the refactor rewrites this branch's `continue` to `return None`
+        # with `if r is not None` in the parent; it had zero coverage before).
+        config: dict[str, Any] = {
+            "version": 1,
+            "sources": [{**_TRENDING_SOURCE, "url": ""}],
+        }
+        storage = InMemoryStorage()
+        notifier = InMemoryNotifier()
+        with unittest.mock.patch(
+            "kinozal_scraper.github_trending_pipeline.fetch_html",
+            return_value=_fixture_html(),
+        ):
+            with self.assertLogs(
+                "kinozal_scraper.github_trending_pipeline", level="WARNING"
+            ) as captured:
+                results = run_github_trending_pipeline(
+                    storage, notifier, sources_config=config
+                )
+
+        self.assertEqual(results, [])
+        self.assertTrue(any("no URL configured" in line for line in captured.output))
+        self.assertEqual(storage.stored_rows("github_projects"), [])
+        self.assertEqual(notifier.sent, [])
+
 
 # ── #88: Russian who/pain enrichment for trending ────────────────────────────
 


### PR DESCRIPTION
## Summary

Распил grandfather'нутой `run_github_trending_pipeline` (PLR0915=68 при пороге 50 + C901/PLR0912 под `# noqa`) на 3 module-private helper'а, после чего noqa снят (§V: noqa маскирует, распил лечит — коды гаснут → иначе RUF100). Родитель и каждый helper проходят пороги C901=12 / PLR0912=12 / PLR0915=50. Вторая функция из follow-up #251 (после #269/#270).

**Divergence от issue outline:** совпало с планом. Architect-review (SHOULD-FIX #1) заранее выявил, что ветки no-url и fetch-fail имеют нулевое покрытие, а распил переписывает их exit-механизм (`continue`→`return`) — поэтому в PR добавлены 2 characterization-guard теста ДО реструктуризации (отдельным коммитом).

Closes #271

## Test plan

Чистый распил (§I exception a) для покрытой части — новых тестов нет; guard регресса — существующая suite. Для двух непокрытых веток (no-url, fetch-fail) добавлены characterization-guards.

- [x] `python scripts/ci_check.py` — green локально (ruff format+lint вкл. C901/PLR0912/PLR0915/RUF100 + pytest + mypy + pip-audit + import-linter)
- [x] `tests/test_github_trending_pipeline.py` — 22 passed (вкл. 2 новых guard), бьёт каждую выделенную фазу
- [x] 2 characterization-guards (`TestPipelineMechanics::test_fetch_failure_recorded_in_result_errors`, `::test_no_url_source_skipped_and_absent_from_results`) — зелёные до и после распила; краснеют, если распил сломает переписанные ветки
- [ ] CI на PR — green

**Про RED:** это чистый рефактор, не TDD-фича. `check_red.py` на 2 guard-теста намеренно репортит «not RED» (тесты фиксируют уже существующее поведение перед его переписыванием — characterization, а не red-first). Искусственно ронять их ради зелёного check_red = shim (§V), не делал. Обоснование — в commit-message guard-коммита и в issue Test plan.

## Risk & Rollback

- **Blast-radius:** изолировано — один файл `github_trending_pipeline.py`; публичный API (`run_github_trending_pipeline`) байт-в-байт, порядок фаз / тексты логов/ошибок / no-url silent-skip / quota-fallback-for-remaining сохранены. Задевает только github-trending cron-ветку; kinozal/Sheets-схема/Telegram-формат/Gemini-контракт не тронуты.
- **Rollback:** чистый `git revert`, необратимых эффектов нет.
- **Мониторинг:** ближайший cron-ран `run-script.yml` (github-trending) — но поведение неизменно, риск ~ноль.

## Docs touched

none — behaviour unchanged, helper'ы module-private, doc-ссылок на внутреннюю структуру функции нет.
