### PR TITLE
ci(schedule): сдвинуть cron на 2 часа раньше (03:00 → 01:00 UTC)

### DIFF
--- a/.github/workflows/run-script.yml
+++ b/.github/workflows/run-script.yml
@@ -1,7 +1,7 @@
 name: Run python script
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 1 * * *'
   workflow_dispatch:
 jobs:
   run-script:


### PR DESCRIPTION
## Что и зачем

Cron `0 3 * * *` (03:00 UTC) → `0 1 * * *` (01:00 UTC).

Scheduled-workflows в GitHub Actions — best-effort: за последний месяц ни один запуск не стартовал в срок, фактический старт плавает **+1.5…+3.5 ч** и уезжает в 04:30–06:30 UTC (иногда дропается под нагрузкой). Сдвиг целевого времени на 2 ч раньше держит фактический старт в приемлемом для оператора окне даже с задержкой очереди.

Это не чинит best-effort-природу крона (её починить нельзя без внешнего триггера), а компенсирует её сдвигом окна.

## Scope
Одна строка в `.github/workflows/run-script.yml`. Поведение пайплайна не меняется — только время старта.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)