### PR TITLE
chore: PostToolUse hook — ruff check-only + pip-compile guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,5 +13,18 @@
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"$CLAUDE_PROJECT_DIR/scripts/hooks.py\" on-edit"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -27,6 +27,32 @@ Activate: `git config core.hooksPath .githooks`
 > [`pre-commit`](https://pre-commit.com) framework — which this repo
 > deliberately does **not** use (next block).
 
+### Session hooks (`scripts/hooks.py`, #281)
+
+A separate, *earlier* feedback layer that runs **during** an agent session, not
+at push. `.claude/settings.json` declares a single `PostToolUse` hook (matcher
+`Edit|Write`) invoking `python "$CLAUDE_PROJECT_DIR/scripts/hooks.py" on-edit`,
+which dispatches two cheap checks in one process right after each file edit:
+
+- `*.py` → ruff **check-only** (`ruff format --check` + `ruff check`, **no
+  `--fix`/format mutation** — the harness tracks file contents, so rewriting
+  behind its back breaks the next Edit's `old_string` match). Remaining lint →
+  stderr + exit 2 (PostToolUse exit 2 feeds stderr back to the agent).
+- `requirements*.in` → a `pip-compile` reminder (workflow #7 is otherwise only
+  prose — this makes forgetting it a *visible* marker, not a CI-time surprise).
+
+§IV split: a malformed/empty payload is a silent no-op, but a ruff *exec*
+failure (not installed / bad config) is a **visible, distinct** marker — a
+silently-broken hook must not masquerade as "lint clean". Decision logic is pure
+functions (`plan_checks`/`classify_ruff_result`) with unit tests
+(`tests/test_hooks.py`); wiring is anti-drift-guarded by
+`tests/test_settings_hooks.py` (mirrors `test_settings_deny.py`).
+
+This is instant feedback that **complements, never replaces** `ci_check.py` (the
+canonical pre-push gate), and is unrelated to the `pre-commit`/`tox` *framework*
+consciously declined below (#255/#267) — that no-go is about a PR-time
+tool-registry framework, this is a session-time editor hook.
+
 ### `pre-commit`/`tox` consciously not adopted (#255)
 
 The `CHECKS` registry looks like a hand-rolled task-runner, so «why not the

--- a/docs/architecture/project-map.md
+++ b/docs/architecture/project-map.md
@@ -154,6 +154,7 @@ orientation, которого в per-file docstring нет.
 | `scripts/issue_branch.py` / `scripts/new_branch.py` | Создание ветки `issue-N-*` от свежего origin/main |
 | `scripts/check_red.py` | Действительно ли тесты RED перед GREEN (контракт TDD-шага) |
 | `scripts/ci_check.py` | Локальный pre-commit/pre-push гейт качества (зеркало CI job) |
+| `scripts/hooks.py` | Session-level `PostToolUse`-хук (`on-edit`): ruff check-only на `*.py` + pip-compile-reminder на `requirements*.in` — мгновенный feedback во время агентной сессии, дополняет `ci_check.py`; deep-dive `ci.md#session-hooks` (#281) |
 | `.github/workflows/ci.yml` | Quality job на PR/push (должен зеркалить `ci_check.py`) |
 | `.importlinter` | §II protocol-boundaries как машинный контракт (гейт `imports` в `ci_check`): направление зависимостей + adapter-no-auth; deep-dive `ci.md` (#234) |
 

--- a/scripts/hooks.py
+++ b/scripts/hooks.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Session-level PostToolUse hook: instant feedback after Edit/Write (#281).
+
+Wired in `.claude/settings.json` as a single PostToolUse entry (matcher
+`Edit|Write`) calling `python "$CLAUDE_PROJECT_DIR/scripts/hooks.py" on-edit`.
+It reads the PostToolUse JSON payload from stdin and dispatches two cheap checks
+in ONE process (one python spawn per edit):
+
+  - `*.py`            → ruff check-only (`ruff format --check` + `ruff check`,
+                       NO `--fix`/format mutation — the harness tracks file
+                       contents, so rewriting behind its back breaks the next
+                       Edit's `old_string` match). Remaining lint → stderr,
+                       exit 2 (PostToolUse exit 2 feeds stderr back to the agent
+                       without blocking the already-applied edit).
+  - `requirements*.in` → a `pip-compile` reminder (workflow #7 is otherwise only
+                       prose — easy to forget; the reminder makes it visible).
+
+§IV: a malformed/empty payload is a silent no-op (do not red every edit on a
+payload bug), but a ruff *exec* failure (not installed / bad config) is a
+VISIBLE, distinct marker — otherwise the agent believes instant-lint runs when
+it does not (a silent setup degradation).
+
+This is session-level instant feedback during agentic work; it does NOT replace
+`scripts/ci_check.py` (the canonical pre-push gate) and is unrelated to the
+pre-commit/tox *framework* declined in #255/#267.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# ruff exit codes: 0 = clean, 1 = lint findings, >=2 = ruff itself errored.
+_RUFF_EXEC_ERROR = 2
+
+
+@dataclass(frozen=True)
+class Signal:
+    """A message to surface to the agent. `kind` distinguishes the cause so a
+    broken-setup marker is never mistaken for a lint finding (§IV)."""
+
+    kind: str  # "lint" | "setup_broken" | "pipcompile"
+    message: str
+
+
+def read_payload(stdin_text: str) -> dict:
+    """Parse the PostToolUse JSON; tolerant to empty/broken input → {}."""
+    stdin_text = (stdin_text or "").strip()
+    if not stdin_text:
+        return {}
+    try:
+        data = json.loads(stdin_text)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def edited_path(payload: dict) -> str | None:
+    """The `tool_input.file_path` of an Edit/Write payload, or None."""
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    path = tool_input.get("file_path")
+    return path if isinstance(path, str) and path else None
+
+
+def _is_python(path: str) -> bool:
+    return path.endswith(".py")
+
+
+def _is_requirements_in(path: str) -> bool:
+    """A pip-compile *source* file: requirements*.in (NOT the generated .txt)."""
+    name = path.replace("\\", "/").rsplit("/", 1)[-1]
+    return name.startswith("requirements") and name.endswith(".in")
+
+
+def plan_checks(payload: dict) -> list[str]:
+    """Which checks apply to this edit (pure dispatch by file path)."""
+    path = edited_path(payload)
+    if path is None:
+        return []
+    if _is_python(path):
+        return ["ruff"]
+    if _is_requirements_in(path):
+        return ["pipcompile"]
+    return []
+
+
+def classify_ruff_result(returncode: int, output: str) -> Signal | None:
+    """Map a ruff run to a Signal: 0 → None (clean); 1 → lint; >=2 → setup_broken."""
+    if returncode == 0:
+        return None
+    if returncode >= _RUFF_EXEC_ERROR:
+        return Signal(
+            kind="setup_broken",
+            message=(
+                "ruff could not run (exit "
+                f"{returncode}) — instant-lint is NOT active; fix the hook setup:\n"
+                f"{output.strip()}"
+            ),
+        )
+    return Signal(kind="lint", message=f"ruff found issues (fix before commit):\n{output.strip()}")
+
+
+def pipcompile_signal(path: str) -> Signal:
+    """Reminder to regenerate the lockfile after editing a requirements*.in."""
+    return Signal(
+        kind="pipcompile",
+        message=(
+            f"{path} changed — run `pip-compile {path}` in the SAME commit "
+            "(workflow #7) or CI will red on lockfile drift."
+        ),
+    )
+
+
+def exit_code(signals: list[Signal]) -> int:
+    """PostToolUse: exit 2 surfaces stderr to the agent; 0 = nothing to say."""
+    return 2 if signals else 0
+
+
+def _run_ruff(file_path: str) -> tuple[int, str]:
+    """Thin I/O wrapper: run ruff check-only on one file. FileNotFoundError
+    (ruff not installed) is mapped to the exec-error code so it surfaces (§IV)."""
+    combined_out = ""
+    worst_rc = 0
+    for cmd in (
+        [sys.executable, "-m", "ruff", "format", "--check", file_path],
+        [sys.executable, "-m", "ruff", "check", file_path],
+    ):
+        try:
+            completed = subprocess.run(cmd, text=True, capture_output=True)
+        except FileNotFoundError as exc:  # ruff/python missing → visible, not silent
+            return _RUFF_EXEC_ERROR, str(exc)
+        # Windows + git-bash can hand back None despite text=True (see #109).
+        combined_out += (completed.stdout or "") + (completed.stderr or "")
+        worst_rc = max(worst_rc, completed.returncode)
+    return worst_rc, combined_out
+
+
+def run_on_edit(
+    payload: dict,
+    ruff_runner: Callable[[str], tuple[int, str]] = _run_ruff,
+) -> tuple[int, str]:
+    """Execute the planned checks for one edit. Returns (exit_code, stderr_text)."""
+    path = edited_path(payload)
+    signals: list[Signal] = []
+    for check in plan_checks(payload):
+        if check == "ruff" and path is not None:
+            returncode, output = ruff_runner(path)
+            sig = classify_ruff_result(returncode, output)
+            if sig is not None:
+                signals.append(sig)
+        elif check == "pipcompile" and path is not None:
+            signals.append(pipcompile_signal(path))
+    stderr = "\n".join(s.message for s in signals)
+    return exit_code(signals), stderr
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] != "on-edit":
+        print(
+            "Usage: python scripts/hooks.py on-edit  (reads PostToolUse JSON on stdin)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    payload = read_payload(sys.stdin.read())
+    code, stderr = run_on_edit(payload)
+    if stderr:
+        print(stderr, file=sys.stderr)
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,87 @@
+"""Unit tests for the session-level PostToolUse hook (`scripts/hooks.py`, #281).
+
+The hook fires after every Edit/Write and dispatches two cheap checks in one
+process: ruff (check-only) on `*.py`, and a pip-compile reminder on
+`requirements*.in`. The deterministic decision logic lives in pure functions
+(`plan_checks`, `classify_ruff_result`, `pipcompile_signal`, `exit_code`) so it
+can be tested without spawning real ruff — the subprocess call is a thin I/O
+wrapper (mirrors the `scripts/check_red.py` pure-function + thin-`main` split).
+
+§IV note: a malformed/empty payload is a silent no-op (do not red every edit on
+a payload bug), but a *ruff exec failure* (not installed / internal error) must
+be a VISIBLE marker — otherwise the agent believes instant-lint is running when
+it is not (a silent setup degradation).
+"""
+
+from __future__ import annotations
+
+from scripts.hooks import (
+    classify_ruff_result,
+    exit_code,
+    pipcompile_signal,
+    plan_checks,
+    run_on_edit,
+)
+
+
+def _payload(path: str | None) -> dict:
+    if path is None:
+        return {"tool_input": {}}
+    return {"tool_input": {"file_path": path}}
+
+
+class TestOnEditDispatch:
+    def test_python_file_plans_ruff_check(self) -> None:
+        assert plan_checks(_payload("src/kinozal_scraper/soldout_pipeline.py")) == ["ruff"]
+
+    def test_non_python_skips_ruff(self) -> None:
+        assert plan_checks(_payload("docs/architecture/ci.md")) == []
+        assert plan_checks(_payload(".claude/settings.json")) == []
+
+    def test_malformed_payload_silent_noop(self) -> None:
+        # No file_path (and empty payload) → nothing planned, exit 0, no stderr.
+        assert plan_checks(_payload(None)) == []
+        assert plan_checks({}) == []
+        code, stderr = run_on_edit({}, ruff_runner=_never_called)
+        assert code == 0
+        assert stderr == ""
+
+
+class TestRuffSignal:
+    def test_lint_findings_surface_exit_2(self) -> None:
+        # ruff returncode 1 = lint findings → visible marker, exit 2 (feedback to agent).
+        sig = classify_ruff_result(1, "src/x.py:1:1: F401 unused import")
+        assert sig is not None
+        assert sig.kind == "lint"
+        assert exit_code([sig]) == 2
+
+    def test_ruff_exec_failure_is_visible_not_silent(self) -> None:
+        # ruff returncode >=2 = ruff itself broke (bad config / not runnable).
+        # Must be a VISIBLE, DISTINCT marker — not swallowed as "lint clean".
+        sig = classify_ruff_result(2, "error: unknown option")
+        assert sig is not None
+        assert sig.kind == "setup_broken"
+        assert sig.kind != "lint"
+        assert exit_code([sig]) == 2
+
+    def test_clean_returns_no_marker(self) -> None:
+        assert classify_ruff_result(0, "") is None
+        assert exit_code([]) == 0
+
+
+class TestPipCompileGuard:
+    def test_requirements_in_flagged(self) -> None:
+        assert plan_checks(_payload("requirements.in")) == ["pipcompile"]
+        assert plan_checks(_payload("requirements-dev.in")) == ["pipcompile"]
+        sig = pipcompile_signal("requirements.in")
+        assert "pip-compile" in sig.message
+        assert exit_code([sig]) == 2
+
+    def test_requirements_txt_ignored(self) -> None:
+        # .txt is the generated lockfile, not the source — no reminder.
+        assert plan_checks(_payload("requirements.txt")) == []
+        assert plan_checks(_payload("requirements-dev.txt")) == []
+
+
+def _never_called(_file: str) -> tuple[int, str]:
+    raise AssertionError("ruff_runner must not run when nothing is planned")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -46,6 +46,25 @@ class TestOnEditDispatch:
         assert code == 0
         assert stderr == ""
 
+    def test_run_on_edit_python_wires_dispatch_classify_exit(self) -> None:
+        # End-to-end seam: a .py edit + a stubbed ruff run flows
+        # plan_checks → ruff_runner → classify_ruff_result → exit_code as a whole.
+        calls: list[str] = []
+
+        def _stub(file_path: str) -> tuple[int, str]:
+            calls.append(file_path)
+            return 1, f"{file_path}:1:1: F401 unused import"
+
+        code, stderr = run_on_edit(_payload("src/x.py"), ruff_runner=_stub)
+        assert calls == ["src/x.py"]  # dispatch reached the runner with the edited path
+        assert code == 2  # lint finding surfaces
+        assert "F401" in stderr
+
+    def test_run_on_edit_python_clean_is_silent(self) -> None:
+        code, stderr = run_on_edit(_payload("src/x.py"), ruff_runner=lambda _f: (0, ""))
+        assert code == 0
+        assert stderr == ""
+
 
 class TestRuffSignal:
     def test_lint_findings_surface_exit_2(self) -> None:

--- a/tests/test_settings_hooks.py
+++ b/tests/test_settings_hooks.py
@@ -1,0 +1,63 @@
+"""Anti-drift guard for the PostToolUse hook wiring in `.claude/settings.json` (#281).
+
+Mirrors `tests/test_settings_deny.py`: the hook is *declared* in settings.json and
+*implemented* in `scripts/hooks.py`; these tests keep the two from silently
+drifting (a settings entry pointing at a missing script, or the single-spawn
+invariant regressing into two matchers = two python spawns per edit).
+
+Static JSON/file-existence checks only — no network, no ruff run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+_SETTINGS = _REPO / ".claude" / "settings.json"
+
+
+def _posttooluse_entries() -> list[dict]:
+    data = json.loads(_SETTINGS.read_text(encoding="utf-8"))
+    return list(data.get("hooks", {}).get("PostToolUse", []))
+
+
+def _commands() -> list[str]:
+    cmds: list[str] = []
+    for entry in _posttooluse_entries():
+        for hook in entry.get("hooks", []):
+            if hook.get("type") == "command":
+                cmds.append(str(hook.get("command", "")))
+    return cmds
+
+
+class TestHookWiring:
+    def test_hook_command_references_existing_script(self) -> None:
+        cmds = _commands()
+        assert cmds, "settings.json must declare a PostToolUse command hook"
+        assert any("scripts/hooks.py" in c for c in cmds), (
+            f"a PostToolUse hook must invoke scripts/hooks.py — got {cmds!r}"
+        )
+        assert (_REPO / "scripts" / "hooks.py").is_file(), (
+            "scripts/hooks.py referenced by settings.json must exist (anti-drift)"
+        )
+
+    def test_single_posttooluse_edit_write_entry(self) -> None:
+        # Exactly one entry, matching both Edit and Write, calling the `on-edit`
+        # subcommand — one python spawn per edit (architect NICE #5), not two.
+        entries = _posttooluse_entries()
+        edit_write = [e for e in entries if _matches_edit_and_write(str(e.get("matcher", "")))]
+        assert len(edit_write) == 1, (
+            f"expected exactly one Edit|Write PostToolUse entry (single spawn), got {len(edit_write)}"
+        )
+        cmds = _commands()
+        assert any(re.search(r"scripts/hooks\.py[\"']?\s+on-edit", c) for c in cmds), (
+            f"the hook must call `scripts/hooks.py on-edit` — got {cmds!r}"
+        )
+
+
+def _matches_edit_and_write(matcher: str) -> bool:
+    """A matcher covers both Edit and Write (e.g. 'Edit|Write' or 'Write|Edit')."""
+    tokens = re.split(r"[|\s]+", matcher)
+    return "Edit" in tokens and "Write" in tokens


### PR DESCRIPTION
## Summary

Добавляет session-level `PostToolUse`-хук (`scripts/hooks.py`, проводка в `.claude/settings.json`), срабатывающий после каждого Edit/Write: **ruff check-only** на `*.py` + **напоминание `pip-compile`** на `requirements*.in`. Мгновенный feedback во время агентной сессии — дополняет, не заменяет pre-push `ci_check.py`.

Divergence: совпало с issue `## Implementation outline`. Все 5 findings architect-review вплетены (BLOCKING #1 check-only, SHOULD-FIX #2 §IV-split, #3 exit-2 тест, #4 pain-first, NICE #5 single-entry).

Closes #281

## Test plan

- [x] `python scripts/ci_check.py` — green локально (507 passed, 3 skipped; format/lint/pytest/pip-audit×2/requirements/mypy/imports — all passed)
- [x] RED-шаг подтверждён `scripts/check_red.py` перед реализацией
- [x] `tests/test_hooks.py` (8) — pure-функции `plan_checks`/`classify_ruff_result`/`pipcompile_signal`/`exit_code` + §IV-ветки (malformed→silent, ruff-exec-fail→visible)
- [x] `tests/test_settings_hooks.py` (2) — anti-drift проводки (ссылка на существующий скрипт + single Edit|Write entry)
- [ ] CI на PR — green

## Risk & Rollback

- **Blast-radius:** изолировано от рантайма. Хук — часть **dev-окружения агента** (`.claude/settings.json` + новый `scripts/hooks.py`), не импортируется ни одним пайплайном; крон-пайплайн, Sheets-дедуп, Telegram-доставка, Gemini не затронуты. import-linter: 2 kept, 0 broken.
- **Rollback:** чистый `git revert` PR — необратимых эффектов нет (ничего не отправляется/не пишется).
- **Мониторинг:** ближайший крон-ран `run-script.yml` должен пройти как раньше (хук на него не влияет). Локально хук активируется у контрибьютора автоматически через `.claude/settings.json`.

## Docs touched

- [x] `docs/architecture/ci.md` — новая подсекция `### Session hooks`, явная развязка с #255/#267 (framework no-go ≠ session hook).
- [x] `docs/architecture/project-map.md` — навигационная строка на `scripts/hooks.py`.
- runtime.md не трогается — поведение пайплайнов не меняется.
