### PR TITLE
fix: retry SheetsStorage на транзиентные 5xx (500/503) — единый per-call слой

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -84,8 +84,8 @@ Choose the cheapest reliable test for each category.
 ## What does NOT get tested in this repo
 
 - `SheetsStorage` gspread wiring — call order, worksheet creation.
-  (Its **retry-on-429** and **schema validation** *are* tested — see
-  `test_sheets_storage.py::TestSheetsStorageRetryOn429` / `TestSchemaValidation` — because
+  (Its **retry on transient errors (429 + 5xx)** and **schema validation** *are* tested — see
+  `test_sheets_storage.py::TestSheetsStorageRetryTransient` / `TestSchemaValidation` — because
   those are correctness logic mocked at the `gspread.Client` boundary, not internal call order.)
 - `TelegramChannelSummarizer` / Telethon calls.
 - Any code path that requires live credentials.

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -179,6 +179,16 @@ work-for-work (goal-function priority (2)).
   frequent: `test_e2e_kinozal_titles.py`, `test_e2e_github_trending.py`.
 - **C. Auth & quota — GitHub 401 not tested.** The token rarely 401s and a downstream
   zero-row → red CI catches the outage; a dedicated 401 guard is negative-ROI.
+- **K. Sheets 5xx retry — dup-write / already-exists races not tested (#288).** Broadening
+  `SheetsStorage` retry from 429-only to transient 5xx (500/502/503/504) raised the odds of a
+  `append_rows` **duplicate row** on retry: a 5xx that lands *after* the batch partially wrote
+  re-appends on the next attempt (429 usually rejects *before* writing, so this is genuinely
+  newer/likelier than the prior behaviour). **Accepted** — next-run read-dedup (`get_existing_keys`)
+  drops the dup; a test would need live/ambiguous-timing conditions to reproduce (§V documented
+  mitigation, not silent). Same class on `add_worksheet` (5xx after server-side create → retry
+  hits a non-transient "already exists" 4xx → aborts, *doesn't* self-heal) — rarer still (once
+  per tab, ever) and left untested for the same reason. Behaviour is correct; only the timing
+  race is uncovered, recorded here so it isn't re-litigated as work-for-work.
 
 **Scope-skip (can't run without live credentials) — see [What does NOT get tested](#what-does-not-get-tested-in-this-repo):**
 

--- a/src/kinozal_scraper/sheets_storage.py
+++ b/src/kinozal_scraper/sheets_storage.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable
-from typing import Any, Protocol, runtime_checkable
+from collections.abc import Callable, Iterable
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 import gspread
 import gspread.exceptions
@@ -12,13 +12,21 @@ from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponen
 
 from kinozal_scraper.generic_pipeline import ROW_HEADERS
 
+_T = TypeVar("_T")
+
+# Transient Sheets API errors worth retrying: 429 quota + canonical 5xx server
+# blips (500/502/503/504). NOT 4xx permission/not-found (401/403/404) — those
+# are real config/permission faults and must fail fast, surfaced visibly, not
+# masked behind retries (§IV/§V).
+_TRANSIENT_CODES = frozenset({429, 500, 502, 503, 504})
+
 
 class SchemaError(ValueError):
     """Raised when an existing worksheet has an incompatible column schema."""
 
 
-def _is_sheets_rate_limit(exc: BaseException) -> bool:
-    return isinstance(exc, gspread.exceptions.APIError) and exc.code == 429
+def _is_transient_sheets_error(exc: BaseException) -> bool:
+    return isinstance(exc, gspread.exceptions.APIError) and exc.code in _TRANSIENT_CODES
 
 
 @runtime_checkable
@@ -29,22 +37,44 @@ class Storage(Protocol):
 
 
 class SheetsStorage:
-    """Google Sheets backed storage. Accepts an already-authenticated gspread.Client."""
+    """Google Sheets backed storage. Accepts an already-authenticated gspread.Client.
+
+    Every gspread network call routes through the single ``_net`` retry layer, so
+    a transient Sheets 5xx/429 on *any* operation — construction, worksheet
+    lookup/creation, read, or write — is retried rather than crashing the run.
+    Wrapping each call individually (not whole composite methods) keeps exactly
+    one retry layer (no nested 5x5 blow-up) and keeps ``add_worksheet`` /
+    ``append_row(headers)`` atomically separate, so a 5xx while writing headers
+    retries only that call — headers always land, no empty-tab SchemaError.
+    """
 
     def __init__(self, client: gspread.Client, spreadsheet_url: str) -> None:
-        self._spreadsheet = client.open_by_url(spreadsheet_url)
+        self._spreadsheet = self._net(client.open_by_url, spreadsheet_url)
+
+    @staticmethod
+    @retry(
+        retry=retry_if_exception(_is_transient_sheets_error),
+        stop=stop_after_attempt(5),
+        wait=wait_exponential(multiplier=1, max=60),
+        reraise=True,
+    )
+    def _net(fn: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+        """Run a single gspread network call, retrying transient 5xx/429."""
+        return fn(*args, **kwargs)
 
     def _get_or_create_worksheet(self, tab_name: str, headers: list[str]) -> gspread.Worksheet:
         try:
-            return self._spreadsheet.worksheet(tab_name)
+            return self._net(self._spreadsheet.worksheet, tab_name)
         except gspread.exceptions.WorksheetNotFound:
-            ws = self._spreadsheet.add_worksheet(title=tab_name, rows=1000, cols=len(headers))
-            ws.append_row(headers)
+            ws = self._net(
+                self._spreadsheet.add_worksheet, title=tab_name, rows=1000, cols=len(headers)
+            )
+            self._net(ws.append_row, headers)
             return ws
 
     def get_existing_keys(self, tab_name: str) -> set[str]:
         ws = self._get_or_create_worksheet(tab_name, ROW_HEADERS)
-        headers = ws.row_values(1)
+        headers = self._net(ws.row_values, 1)
 
         missing = set(ROW_HEADERS) - set(headers)
         if missing:
@@ -54,23 +84,20 @@ class SheetsStorage:
             )
 
         key_col = headers.index("dedupe_key") + 1  # 1-based
-        col_values = ws.col_values(key_col)
+        col_values = self._net(ws.col_values, key_col)
         return {str(v).strip() for v in col_values[1:] if v and str(v).strip()}
 
     def append_rows(self, tab_name: str, headers: list[str], rows: list[list[Any]]) -> None:
         if not rows:
             return
         ws = self._get_or_create_worksheet(tab_name, headers)
-        self._ws_append_rows(ws, rows)
-
-    @retry(
-        retry=retry_if_exception(_is_sheets_rate_limit),
-        stop=stop_after_attempt(5),
-        wait=wait_exponential(multiplier=1, max=60),
-        reraise=True,
-    )
-    def _ws_append_rows(self, ws: gspread.Worksheet, rows: list[list[Any]]) -> None:
-        ws.append_rows(rows, value_input_option=gspread.utils.ValueInputOption.user_entered)
+        # A batch that partially writes before a 5xx can double-write on retry.
+        # 5xx-after-write is likelier than for 429 (429 usually rejects before
+        # writing); we accept it and rely on next-run read-dedup, not "same risk
+        # as 429" (see #288 Out of scope).
+        self._net(
+            ws.append_rows, rows, value_input_option=gspread.utils.ValueInputOption.user_entered
+        )
 
 
 class InMemoryStorage:

--- a/tests/test_sheets_storage.py
+++ b/tests/test_sheets_storage.py
@@ -113,15 +113,29 @@ class TestInMemoryStorage(unittest.TestCase):
         self.assertEqual(self.storage.stored_rows("movies"), [])
 
 
-class TestSheetsStorageRetryOn429(unittest.TestCase):
-    """append_rows retries on Sheets 429 (quota) with exponential backoff."""
+class TestSheetsStorageRetryTransient(unittest.TestCase):
+    """Every SheetsStorage network call retries on transient Sheets errors
+    (429 quota + 5xx 500/502/503/504) with exponential backoff, via a single
+    per-call retry layer. Non-transient 4xx (permission/not-found) fail fast.
+    """
 
     def _build(self, side_effect: list[Any]) -> tuple[SheetsStorage, MagicMock]:
+        """Storage whose worksheet().append_rows raises the given side_effect."""
         client = MagicMock(spec=gspread.Client)
         worksheet = MagicMock()
         worksheet.append_rows.side_effect = side_effect
         client.open_by_url.return_value.worksheet.return_value = worksheet
         return SheetsStorage(client, "https://sheets.example/url"), worksheet
+
+    def _storage_with_spreadsheet(self) -> tuple[SheetsStorage, MagicMock]:
+        """Storage constructed cleanly; returns (storage, spreadsheet mock) so a
+        test can drive worksheet()/row_values() seams directly."""
+        spreadsheet = MagicMock()
+        client = MagicMock(spec=gspread.Client)
+        client.open_by_url.return_value = spreadsheet
+        return SheetsStorage(client, "https://sheets.example/url"), spreadsheet
+
+    # --- 429 kept green: broadening must not break the original quota retry ---
 
     @patch("tenacity.nap.time.sleep")
     def test_429_then_success_retries_and_succeeds(self, _sleep: MagicMock) -> None:
@@ -137,7 +151,83 @@ class TestSheetsStorageRetryOn429(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 429)
         self.assertEqual(worksheet.append_rows.call_count, 5)
 
-    def test_non_429_api_error_not_retried(self) -> None:
+    # --- 5xx on write ---
+
+    @patch("tenacity.nap.time.sleep")
+    def test_503_then_success_retries_on_append(self, _sleep: MagicMock) -> None:
+        storage, worksheet = self._build([_api_error(503, "unavailable"), None])
+        storage.append_rows("movies", ROW_HEADERS, [_item("k1").to_row()])
+        self.assertEqual(worksheet.append_rows.call_count, 2)
+
+    @patch("tenacity.nap.time.sleep")
+    def test_500_then_success_retries_on_append(self, _sleep: MagicMock) -> None:
+        storage, worksheet = self._build([_api_error(500, "internal"), None])
+        storage.append_rows("movies", ROW_HEADERS, [_item("k1").to_row()])
+        self.assertEqual(worksheet.append_rows.call_count, 2)
+
+    @patch("tenacity.nap.time.sleep")
+    def test_append_5xx_retries_exactly_5_attempts(self, _sleep: MagicMock) -> None:
+        # Single retry layer: 5 attempts, NOT 5x5=25 from nested @retry.
+        storage, worksheet = self._build([_api_error(503, "unavailable")] * 5)
+        with self.assertRaises(gspread.exceptions.APIError) as ctx:
+            storage.append_rows("movies", ROW_HEADERS, [_item("k1").to_row()])
+        self.assertEqual(ctx.exception.code, 503)
+        self.assertEqual(worksheet.append_rows.call_count, 5)
+
+    # --- 5xx on construction (the actual crash site) ---
+
+    @patch("tenacity.nap.time.sleep")
+    def test_open_by_url_503_then_success_retries(self, _sleep: MagicMock) -> None:
+        client = MagicMock(spec=gspread.Client)
+        client.open_by_url.side_effect = [_api_error(503, "unavailable"), MagicMock()]
+        SheetsStorage(client, "https://sheets.example/url")  # must not raise
+        self.assertEqual(client.open_by_url.call_count, 2)
+
+    # --- 5xx on worksheet lookup (shared seam — covers read AND append paths) ---
+
+    @patch("tenacity.nap.time.sleep")
+    def test_worksheet_lookup_503_then_success_retries(self, _sleep: MagicMock) -> None:
+        storage, spreadsheet = self._storage_with_spreadsheet()
+        ws = MagicMock()
+        ws.row_values.return_value = list(ROW_HEADERS)
+        ws.col_values.return_value = ["dedupe_key", "k1"]
+        spreadsheet.worksheet.side_effect = [_api_error(503, "unavailable"), ws]
+        keys = storage.get_existing_keys("movies")
+        self.assertEqual(spreadsheet.worksheet.call_count, 2)
+        self.assertIn("k1", keys)
+
+    # --- 5xx on read ---
+
+    @patch("tenacity.nap.time.sleep")
+    def test_get_existing_keys_502_then_success_retries(self, _sleep: MagicMock) -> None:
+        storage, spreadsheet = self._storage_with_spreadsheet()
+        ws = MagicMock()
+        ws.row_values.side_effect = [_api_error(502, "bad gateway"), list(ROW_HEADERS)]
+        ws.col_values.return_value = ["dedupe_key", "k1"]
+        spreadsheet.worksheet.return_value = ws
+        keys = storage.get_existing_keys("movies")
+        self.assertEqual(ws.row_values.call_count, 2)
+        self.assertIn("k1", keys)
+
+    # --- fail-fast on non-transient 4xx (guard against over-retry) ---
+
+    def test_non_transient_403_not_retried_on_open(self) -> None:
+        client = MagicMock(spec=gspread.Client)
+        client.open_by_url.side_effect = [_api_error(403, "Forbidden")]
+        with self.assertRaises(gspread.exceptions.APIError) as ctx:
+            SheetsStorage(client, "https://sheets.example/url")
+        self.assertEqual(ctx.exception.code, 403)
+        self.assertEqual(client.open_by_url.call_count, 1)
+
+    def test_non_transient_404_not_retried_on_read(self) -> None:
+        storage, spreadsheet = self._storage_with_spreadsheet()
+        spreadsheet.worksheet.side_effect = [_api_error(404, "Not Found")]
+        with self.assertRaises(gspread.exceptions.APIError) as ctx:
+            storage.get_existing_keys("movies")
+        self.assertEqual(ctx.exception.code, 404)
+        self.assertEqual(spreadsheet.worksheet.call_count, 1)
+
+    def test_non_transient_401_not_retried_on_append(self) -> None:
         storage, worksheet = self._build([_api_error(401, "Unauthorized")])
         with self.assertRaises(gspread.exceptions.APIError) as ctx:
             storage.append_rows("movies", ROW_HEADERS, [_item("k1").to_row()])


### PR DESCRIPTION
## Summary

Scheduled-ран [28730041062](https://github.com/ekolvah/kinozal_scraper/actions/runs/28730041062) упал: Google Sheets отдал транзиентные 500/503, `SheetsStorage.__init__ → open_by_url` крашнулся без retry, и все 5 пайплайнов легли (`exit 1`). Первопричина сбоя внешняя (транзиент Google), но краш — следствие двух дыр в нашей retry-обвязке: predicate `_is_sheets_rate_limit` ловил только 429, а `@retry` висел только на записи (`_ws_append_rows`), не на конструировании/чтении/worksheet-lookup.

**Fix (closes #288):**
- `_is_sheets_rate_limit` → `_is_transient_sheets_error`: `_TRANSIENT_CODES = {429, 500, 502, 503, 504}`. 4xx (401/403/404 permission/not-found) НЕ ретраятся — fail-fast, видимая аномалия (§IV/§V).
- Единый per-call wrapper `_net` прогоняет **каждый** gspread-вызов (open / worksheet / add_worksheet / append_row / row_values / col_values / append_rows). **Один** retry-слой — снят старый method-level `@retry` с `_ws_append_rows`, нет вложенных `@retry` (5×5=25). `add_worksheet` и `append_row(headers)` атомарно-раздельны → 5xx на записи заголовков ретраит только её, edge «пустой таб → SchemaError» исчезает.
- Тот же tenacity-конфиг: `stop_after_attempt(5)`, `wait_exponential(1, max=60)`, `reraise=True` — стойкий транзиент всплывает наружу.

Architect-review (BLOCKING про незакрытый append-seam + nested-@retry) устранён в плане до кода — детали в issue #288 `## Architect review`.

## Test plan

`tests/test_sheets_storage.py::TestSheetsStorageRetryTransient` (был `RetryOn429`, расширен). RED-first матрица (6 тестов падали на старом коде, теперь зелёные):
- 5xx на записи: `test_503_then_success_retries_on_append`, `test_500_...`, `test_append_5xx_retries_exactly_5_attempts` (5 не 25).
- 5xx на конструировании: `test_open_by_url_503_then_success_retries`.
- 5xx на worksheet-lookup (общий seam, бьёт read+append): `test_worksheet_lookup_503_then_success_retries`.
- 5xx на чтении: `test_get_existing_keys_502_then_success_retries`.

Регресс-guard (остались зелёными): `test_429_then_success_retries...`, `test_429_repeated...`, fail-fast `test_non_transient_403_not_retried_on_open` / `404_on_read` / `401_on_append`.

`python scripts/ci_check.py` — зелёный (ruff format+lint + pytest + mypy + pip-audit + drift + import-linter). 30 sheets-тестов проходят.

## Risk & Rollback

**Risk:** низкий. Изменение локализовано в `SheetsStorage`; внешний контракт (`Storage` Protocol) не тронут. Broadening retry не маскирует реальные ошибки — 4xx fail-fast сохранён и покрыт тестами. Известный defer: `append_rows`-батч при 5xx-after-write может дублировать строки на повторе — гасится read-дедупом следующего рана (§V documented mitigation, #288 Out of scope), не решается здесь.

**Rollback:** revert коммита — retry вернётся к 429-only на записи (прежнее поведение), функциональность не ломается.

## Docs touched

`docs/architecture/testing.md` — строка про Sheets-retry: «retry-on-429» → «retry on transient errors (429 + 5xx)», ссылка на класс `TestSheetsStorageRetryOn429` → `TestSheetsStorageRetryTransient`.
