### PR TITLE
распил _run_single_source в helper, снять noqa (#290)

### DIFF
--- a/src/kinozal_scraper/github_popular_pipeline.py
+++ b/src/kinozal_scraper/github_popular_pipeline.py
@@ -10,6 +10,7 @@ import requests
 from kinozal_scraper.gemini_enricher import FALLBACK_MARKER, Enricher, QuotaExhausted
 from kinozal_scraper.generic_pipeline import (
     ROW_HEADERS,
+    NormalizedItem,
     PipelineResult,
     build_notification,
     extract_from_json,
@@ -74,7 +75,46 @@ def run_github_popular_pipeline(
     return results
 
 
-def _run_single_source(  # noqa: C901
+def _enrich_new_items(
+    new_items: list[NormalizedItem],
+    enrich_config: dict[str, Any],
+    enricher: Enricher,
+    source_id: str,
+) -> None:
+    """Enrich each new item in-place, stopping on quota exhaustion.
+
+    On `QuotaExhausted` the current and all remaining items get the fallback
+    marker (visible tripwire, #128) so a mid-batch quota outage surfaces in the
+    notification rather than silently blanking the field (§IV)."""
+    field = enrich_config["field"]
+    # Empty `on_error` would silently blank the enriched field — use
+    # the visible marker so the operator sees a tripwire (#128).
+    fallback: str = enrich_config.get("on_error") or FALLBACK_MARKER
+    enriched, skipped = 0, 0
+    for item in new_items:
+        try:
+            item.raw[field] = enricher.enrich(item, enrich_config)
+            enriched += 1
+        except QuotaExhausted:
+            item.raw[field] = fallback
+            skipped += 1
+            for remaining in new_items[new_items.index(item) + 1 :]:
+                remaining.raw[field] = fallback
+                skipped += 1
+            break
+    if skipped:
+        logger.warning(
+            "[%s] enrichment quota exhausted: %d/%d enriched, %d skipped",
+            source_id,
+            enriched,
+            enriched + skipped,
+            skipped,
+        )
+    elif enriched:
+        logger.info("[%s] enriched %d items", source_id, enriched)
+
+
+def _run_single_source(
     source: dict[str, Any],
     storage: Storage,
     notifier: Notifier,
@@ -118,32 +158,7 @@ def _run_single_source(  # noqa: C901
 
     enrich_config = source.get("enrich")
     if enrich_config and enricher is not None:
-        field = enrich_config["field"]
-        # Empty `on_error` would silently blank the enriched field — use
-        # the visible marker so the operator sees a tripwire (#128).
-        fallback: str = enrich_config.get("on_error") or FALLBACK_MARKER
-        enriched, skipped = 0, 0
-        for item in new_items:
-            try:
-                item.raw[field] = enricher.enrich(item, enrich_config)
-                enriched += 1
-            except QuotaExhausted:
-                item.raw[field] = fallback
-                skipped += 1
-                for remaining in new_items[new_items.index(item) + 1 :]:
-                    remaining.raw[field] = fallback
-                    skipped += 1
-                break
-        if skipped:
-            logger.warning(
-                "[%s] enrichment quota exhausted: %d/%d enriched, %d skipped",
-                source_id,
-                enriched,
-                enriched + skipped,
-                skipped,
-            )
-        elif enriched:
-            logger.info("[%s] enriched %d items", source_id, enriched)
+        _enrich_new_items(new_items, enrich_config, enricher, source_id)
 
     template = source["message_template"]
     notifications = [build_notification(item, template) for item in new_items]


### PR DESCRIPTION
## Summary

Follow-up к #251 (распил grandfather'нутых complexity-функций). Извлёк enrich-фазу
(`:119-146`, самый крупный branch-кластер) из `_run_single_source` в module-level
`_enrich_new_items`; в оркестраторе — inline-guard + вызов. `# noqa: C901` снята
(C901 13 → под порогом: родитель ~6, helper ~8), RUF100 чист. Совпало с issue
`## Implementation outline` — хватило одного извлечения, вторая фаза (unwrap+sort)
не понадобилась. Поведение байт-в-байт неизменно.

Closes #290

## Test plan

- [x] `python scripts/ci_check.py` — green локально (ruff format+lint + pytest + mypy + pip-audit + drift + import-linter)
- [x] `tests/test_github_popular_pipeline.py` — 26 passed до и после (characterization-guard, все enrich-ветки пре-покрыты)
- [x] `ruff --select C901 --ignore-noqa` — родитель+helper < 12; RUF100 не краснеет
- [ ] CI на PR — green

Чистый рефактор (§I exception a): публичный контракт не меняется → без red-first тестов;
все ветки извлекаемого блока (guard TRUE/FALSE, QuotaExhausted+fallback-остаток,
skipped-vs-enriched-лог) уже покрыты существующей suite (architect-review verified).

## Risk & Rollback

- **Blast-radius:** изолировано. Затронут только github_popular-пайплайн; enrich-семантика
  (§IV visible FALLBACK_MARKER, WARNING-лог), персист-только-delivered и surface-failed
  перенесены verbatim / остались в родителе — не тронуты. Sheets-дедуп / Telegram-доставка
  не задеты.
- **Rollback:** чистый `git revert` PR, необратимых эффектов нет (код-рефактор, без миграций/IO).
- **Мониторинг:** ближайший крон-ран `run-script.yml` — github_popular шлёт те же новинки
  с тем же enriched-полем.