### PR TITLE
распил _fetch_channel_async (TelethonReader) в _format_messages, снять noqa (closes #294)

### DIFF
--- a/src/kinozal_scraper/TelegramChannelSummarizer.py
+++ b/src/kinozal_scraper/TelegramChannelSummarizer.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import google.api_core.exceptions
 import google.generativeai as genai
@@ -168,7 +168,38 @@ class TelethonReader:
     def fetch_channel(self, channel_url: str) -> ChannelMessages:
         return asyncio.run(self._fetch_channel_async(channel_url))
 
-    async def _fetch_channel_async(self, channel_url: str) -> ChannelMessages:  # noqa: C901, PLR0912
+    @staticmethod
+    def _format_messages(
+        recent_messages: list[Any], users: dict[Any, Any], is_broadcast: bool
+    ) -> list[str]:
+        """Render recent messages to display lines: raw text for broadcast
+        channels, ``"<sender>: <text>"`` otherwise (sender-name resolved
+        full-name → username → id → "Unknown"). Empty-text messages are dropped.
+        Pure transform (no I/O, no ``self``) — extracted verbatim from
+        ``_fetch_channel_async`` to keep both under the complexity threshold (#294)."""
+        formatted_messages: list[str] = []
+        for message in recent_messages:
+            if not message.message:
+                continue
+            if is_broadcast:
+                formatted_messages.append(message.message)
+                continue
+
+            sender_name = "Unknown"
+            if message.sender_id:
+                sender = users.get(message.sender_id)
+                if sender:
+                    first = sender.first_name or ""
+                    last = sender.last_name or ""
+                    sender_name = f"{first} {last}".strip()
+                    if not sender_name and sender.username:
+                        sender_name = sender.username
+                    if not sender_name:
+                        sender_name = str(sender.id)
+            formatted_messages.append(f"{sender_name}: {message.message}")
+        return formatted_messages
+
+    async def _fetch_channel_async(self, channel_url: str) -> ChannelMessages:
         target: str | int = channel_url
         if isinstance(channel_url, str) and channel_url.lstrip("-").isdigit():
             target = int(channel_url)
@@ -205,28 +236,9 @@ class TelethonReader:
 
             users = {user.id: user for user in posts.users}
 
-            formatted_messages: list[str] = []
             is_broadcast: bool = getattr(entity, "broadcast", False)
             logger.info("Channel '%s' is_broadcast: %s", channel_title, is_broadcast)
-            for message in recent_messages:
-                if not message.message:
-                    continue
-                if is_broadcast:
-                    formatted_messages.append(message.message)
-                    continue
-
-                sender_name = "Unknown"
-                if message.sender_id:
-                    sender = users.get(message.sender_id)
-                    if sender:
-                        first = sender.first_name or ""
-                        last = sender.last_name or ""
-                        sender_name = f"{first} {last}".strip()
-                        if not sender_name and sender.username:
-                            sender_name = sender.username
-                        if not sender_name:
-                            sender_name = str(sender.id)
-                formatted_messages.append(f"{sender_name}: {message.message}")
+            formatted_messages = self._format_messages(recent_messages, users, is_broadcast)
 
             if not formatted_messages:
                 logger.info("No text messages found in channel: %s", channel_url)

--- a/tests/test_telegram_summarizer.py
+++ b/tests/test_telegram_summarizer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import unittest
 import unittest.mock
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 
 import google.api_core.exceptions
@@ -280,6 +282,113 @@ class TestTelethonReaderErrorSwallow(unittest.TestCase):
 
         self.assertEqual(result, (None, "", False))
         mock_client.disconnect.assert_awaited_once()
+
+
+# ── C2. Happy-path rendering — TelethonReader._fetch_channel_async ───────────
+#
+# Characterization guard for the render path (broadcast / sender-name fallbacks /
+# day-cutoff / empty-text) written BEFORE the `_format_messages` split (#294), so
+# the extraction is caught if it drifts. Telethon `TelegramClient` is an external
+# boundary (§II) — mocked. Fakes are duck-typed data holders.
+
+
+def _msg(text: str, sender_id: int | None = None, *, recent: bool = True) -> SimpleNamespace:
+    when = datetime.now(UTC) - (timedelta(hours=1) if recent else timedelta(days=2))
+    return SimpleNamespace(message=text, sender_id=sender_id, date=when)
+
+
+def _user(uid: int, first: str = "", last: str = "", username: str = "") -> SimpleNamespace:
+    return SimpleNamespace(id=uid, first_name=first, last_name=last, username=username)
+
+
+def _entity(title: str = "Chan", *, broadcast: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(title=title, broadcast=broadcast)
+
+
+def _posts(messages: list[SimpleNamespace], users: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(messages=messages, users=users)
+
+
+def _mock_client(entity: SimpleNamespace, posts: SimpleNamespace) -> unittest.mock.MagicMock:
+    client = unittest.mock.MagicMock()
+    client.start = unittest.mock.AsyncMock()
+    client.is_user_authorized = unittest.mock.AsyncMock(return_value=True)
+    client.get_entity = unittest.mock.AsyncMock(return_value=entity)
+    client.disconnect = unittest.mock.AsyncMock()
+
+    async def _call(_request: Any) -> SimpleNamespace:  # await client(GetHistoryRequest(...))
+        return posts
+
+    client.side_effect = _call
+    return client
+
+
+class TestTelethonReaderFetchRender(unittest.TestCase):
+    def _fetch(
+        self, url: str, entity: SimpleNamespace, posts: SimpleNamespace
+    ) -> tuple[ChannelMessages, unittest.mock.MagicMock]:
+        reader = TelethonReader(api_id="x", api_hash="y", session=None, phone="p")
+        client = _mock_client(entity, posts)
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.TelegramChannelSummarizer.TelegramClient", return_value=client
+            ),
+            unittest.mock.patch("kinozal_scraper.TelegramChannelSummarizer.GetHistoryRequest"),
+        ):
+            result = reader.fetch_channel(url)
+        return result, client
+
+    def test_broadcast_channel_returns_raw_messages(self) -> None:
+        # broadcast → raw text, no `sender:` prefix; reverse order; empty `.message`
+        # dropped BEFORE the broadcast-append (order of the two early branches, B1).
+        posts = _posts([_msg("first"), _msg(""), _msg("second")], users=[])
+        result, _ = self._fetch("https://t.me/c", _entity(broadcast=True), posts)
+        self.assertEqual(result, ("Chan", "second\nfirst", True))
+
+    def test_non_broadcast_resolves_sender_full_name(self) -> None:
+        posts = _posts([_msg("hi", sender_id=5)], [_user(5, first="John", last="Doe")])
+        result, client = self._fetch("https://t.me/c", _entity(), posts)
+        self.assertEqual(result, ("Chan", "John Doe: hi", False))
+        client.disconnect.assert_awaited_once()  # `finally: disconnect()` parity
+
+    def test_non_broadcast_sender_falls_back_to_username(self) -> None:
+        posts = _posts([_msg("hi", sender_id=6)], [_user(6, username="jdoe")])
+        result, _ = self._fetch("https://t.me/c", _entity(), posts)
+        self.assertEqual(result, ("Chan", "jdoe: hi", False))
+
+    def test_non_broadcast_sender_falls_back_to_id(self) -> None:
+        posts = _posts([_msg("hi", sender_id=7)], [_user(7)])
+        result, _ = self._fetch("https://t.me/c", _entity(), posts)
+        self.assertEqual(result, ("Chan", "7: hi", False))
+
+    def test_non_broadcast_unknown_sender_no_sender_id(self) -> None:
+        # `if message.sender_id:` false (S1 branch A)
+        posts = _posts([_msg("hi", sender_id=None)], [])
+        result, _ = self._fetch("https://t.me/c", _entity(), posts)
+        self.assertEqual(result, ("Chan", "Unknown: hi", False))
+
+    def test_non_broadcast_sender_not_in_users(self) -> None:
+        # `sender_id` truthy but `users.get()` → None → `if sender:` false (S1 branch B)
+        posts = _posts([_msg("hi", sender_id=99)], [_user(1, first="Other")])
+        result, _ = self._fetch("https://t.me/c", _entity(), posts)
+        self.assertEqual(result, ("Chan", "Unknown: hi", False))
+
+    def test_day_cutoff_filters_old_messages(self) -> None:
+        posts = _posts([_msg("old", recent=False), _msg("new")], users=[])
+        result, _ = self._fetch("https://t.me/c", _entity(broadcast=True), posts)
+        self.assertEqual(result, ("Chan", "new", True))
+
+    def test_empty_text_messages_returns_empty_tuple(self) -> None:
+        # all messages have empty `.message` (NOT an empty list) → the
+        # `if not message.message: continue` branch drops every one (B1).
+        posts = _posts([_msg(""), _msg("")], users=[])
+        result, _ = self._fetch("https://t.me/c", _entity(broadcast=True), posts)
+        self.assertEqual(result, ("Chan", "", True))
+
+    def test_numeric_channel_url_coerced_to_int(self) -> None:
+        posts = _posts([_msg("x")], users=[])
+        _, client = self._fetch("-100123", _entity(broadcast=True), posts)
+        client.get_entity.assert_awaited_once_with(-100123)
 
 
 # ── F. Message rendering — format_summary_message ───────────────────────────


### PR DESCRIPTION
## Что и зачем

Финальная (6-я) grandfather-функция трекера #251 — `TelethonReader._fetch_channel_async`
(`# noqa: C901, PLR0912`; без noqa C901=13, PLR0912=14). Синхронный цикл форматирования
сообщений вынесен в `@staticmethod _format_messages(recent_messages, users, is_broadcast)`,
noqa снята. **Закрывает #251** (последняя функция).

## Как

- **Guard-first** (отдельный коммит `c2972ec`): happy-path reader'а был покрыт только на
  except-swallow пути. Добавлен `TestTelethonReaderFetchRender` (9 characterization-тестов:
  broadcast / sender-name фолбэки full→username→id→Unknown ×2-ветки / day-cutoff / empty-text
  drop / numeric-target coercion) через мокнутый `TelegramClient` — зелёные на старом коде,
  стерегут извлечение.
- **Refactor** (коммит `445a46c`): цикл `:211-229` → `_format_messages` (verbatim, без `self`,
  без `await`). Родитель и helper оба ≤10 по C901/PLR0912 (isolated-замер). `reverse()`,
  логи `is_broadcast`/«No text messages», swallow-путь — остаются в родителе.

## Поведение

Байт-в-байт неизменно: тот же кортеж `(title, text, is_broadcast)`, порядок, sender-фолбэки,
day-cutoff, swallow. Чистый refactor + усиление покрытия (не gap).

## Проверки

- `python scripts/ci_check.py` зелёный (ruff+pytest+mypy+pip-audit+import-linter+drift).
- 40/40 tests в `tests/test_telegram_summarizer.py`.

Architect-review плана: 1 BLOCKING + 2 SHOULD-FIX (empty-text ветка внутри helper; 2 «Unknown»-ветки;
тесный узел = helper ~11, не родитель) — все устранены до реализации (см. #294 §Architect review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
