### PR TITLE
fix: fetch_bytes шлёт image-style Accept — постеры с content-negotiating хостов (imageban.ru, fastpic) (closes #296)

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -189,6 +189,16 @@ work-for-work (goal-function priority (2)).
   hits a non-transient "already exists" 4xx → aborts, *doesn't* self-heal) — rarer still (once
   per tab, ever) and left untested for the same reason. Behaviour is correct; only the timing
   race is uncovered, recorded here so it isn't re-litigated as work-for-work.
+- **L. `fetch_bytes` image-`Accept` header / impersonate-profile merge — verified live only (#296).**
+  The fix makes `fetch_bytes` send an `<img>`-style `Accept: image/*` so content-negotiating hosts
+  (imageban.ru, fastpic) serve the JPEG instead of an HTML landing page. The unit test
+  (`test_sends_image_accept_header`) asserts the header is *passed* to `requests.get`, but **cannot**
+  observe curl_cffi's real behaviour: that `headers=` merges by key over the impersonate profile
+  (so UA / Sec-Ch-Ua / TLS fingerprint — the #217/#225 403-avoidance — survive) and that the target
+  host actually returns image bytes. Both were verified live against imageban/fastpic + a
+  header-echo endpoint; the standing gate is the daily cron E2E (a fingerprint regression → 403 on
+  posters → §IV-visible next run), same «cron = E2E smoke» doctrine as **A**. Recorded so the
+  live-only verification isn't re-opened as a mock-the-network work-for-work test.
 
 **Scope-skip (can't run without live credentials) — see [What does NOT get tested](#what-does-not-get-tested-in-this-repo):**
 

--- a/src/kinozal_scraper/http_fetch.py
+++ b/src/kinozal_scraper/http_fetch.py
@@ -43,13 +43,26 @@ def fetch_bytes(url: str) -> bytes:
     our side and upload them to Telegram as multipart, because `sendPhoto`-by-URL
     is fetched by Telegram's own servers, which Cloudflare blocks.
 
+    Requests the asset AS an image — an `<img>`-style `Accept: image/*` (#296).
+    curl_cffi's chrome-impersonate default sends a *navigation* Accept
+    (`text/html,...`), and content-negotiating hosts (imageban.ru, fastpic) answer
+    that with a 200 `text/html` landing page instead of the JPEG → the poster is
+    lost. The header is passed to `requests.get` as an override: curl_cffi merges
+    it by key over the impersonate profile, so UA / Sec-Ch-Ua / TLS fingerprint
+    (the #217/#225 403-avoidance) stay intact — only `Accept` changes.
+
     Guards against the #265 anti-hotlink trap: a 200 `text/html` response is NOT
-    image bytes → `NotAnImageError`. This is a **blocklist** (`text/html`), not an
-    `image/*` allowlist — posters live on a long tail of uploader hosts that may
-    serve exotic content-types, and blocking the one observed garbage class
-    (viewer page) avoids false-positives on a valid image with an odd type.
+    image bytes → `NotAnImageError`. With the image `Accept` above this is now
+    **defense-in-depth** for the rare host that still returns HTML — a blocklist
+    (`text/html`), not an `image/*` allowlist, since posters live on a long tail
+    of uploader hosts that may serve valid images with exotic content-types.
     """
-    resp = requests.get(url, impersonate="chrome", timeout=30)
+    resp = requests.get(
+        url,
+        impersonate="chrome",
+        timeout=30,
+        headers={"Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8"},
+    )
     resp.raise_for_status()
     content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
     if content_type == "text/html":

--- a/tests/test_http_fetch.py
+++ b/tests/test_http_fetch.py
@@ -67,6 +67,24 @@ class TestFetchBytes(unittest.TestCase):
         ):
             fetch_bytes("https://example.com/poster.jpg")
 
+    def test_sends_image_accept_header(self) -> None:
+        # #296: fetch_bytes downloads an IMAGE, so it must request one — an
+        # `<img>`-style `Accept: image/*`. curl_cffi's chrome-impersonate default
+        # sends a *navigation* Accept (text/html,...), and content-negotiating
+        # hosts (imageban.ru, fastpic) answer that with a 200 text/html landing
+        # page instead of the JPEG (→ poster dropped). Load-bearing invariant:
+        # Accept prefers image/*, no text/html priority — assert the prefix, not
+        # a byte-exact q-value string.
+        mock_resp = unittest.mock.Mock()
+        mock_resp.content = b"\xff\xd8\xff\xe0JPEG"
+        mock_resp.headers = {"content-type": "image/jpeg"}
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get", return_value=mock_resp
+        ) as mget:
+            fetch_bytes("https://i4.imageban.ru/out/2026/07/04/x.jpg")
+        _, kwargs = mget.call_args
+        self.assertTrue(kwargs["headers"]["Accept"].startswith("image/"))
+
     def test_raises_not_an_image_on_text_html(self) -> None:
         # #265: a fastpic anti-hotlink viewer page returns 200 text/html (~300 KB).
         # fetch_bytes must NOT hand that HTML back as "poster bytes" — it raises a


### PR DESCRIPTION
## Summary

`fetch_bytes` скачивал постер с *навигационным* `Accept` (chrome-impersonate по умолчанию шлёт `text/html,...`). imageban.ru и fastpic делают content-negotiation по `Accept` → отдавали HTML-заглушку вместо JPEG → guard #265 → нотификатор деградировал до текста без постера. Фикс host-agnostic: `fetch_bytes` шлёт `<img>`-стиль `Accept: image/*`. Проверено вживую (curl_cffi impersonate=chrome) — один заголовок чинит **и imageban (78 KB JPEG), и fastpic #265 (17 KB JPEG вместо 301 KB viewer)**; curl_cffi мержит header по ключу, UA/Sec-Ch-Ua/TLS-fingerprint (403-avoidance #217/#225) целы. Совпало с issue `## Implementation outline`.

Closes #296

## Test plan

- [x] `tests/test_http_fetch.py::TestFetchBytes::test_sends_image_accept_header` — RED→GREEN (Accept начинается с `image/`)
- [x] регресс-guard: `test_passes_impersonate_chrome_and_returns_content`, `test_raises_not_an_image_on_text_html` (#265), `TestFetchHtml` — зелёные (fetch_html не тронут)
- [x] `python scripts/ci_check.py` — green локально (ruff/pytest/mypy/pip-audit/drift/import-linter)
- [ ] CI на PR — green
- [ ] fingerprint-регресс (юнит-мок не видит) — гейт = ближайший daily cron-E2E `run-script.yml`

## Risk & Rollback

- **Blast-radius:** изолировано — одна строка `headers=` в `fetch_bytes` (используется только для скачивания постеров: `kinozal.fetch_poster` + дефолтный `image_fetcher` нотификатора). `fetch_html`, Sheets-дедуп, Gemini, Telegram-доставка не затронуты.
- **Rollback:** чистый `git revert`, необратимых эффектов нет.
- **Мониторинг:** ближайший крон-ран `run-script.yml` — постеры kinozal-раздач приходят (в т.ч. с imageban/fastpic), 403 на постерах не появились.

## Docs touched

none — behaviour внутренний, публичный контракт `fetch_bytes(url)->bytes` не меняется; `.md`-канона по poster-fetch нет (`git grep` пусто). Живая характеристика imageban/fastpic зафиксирована в теле #296.
