### PR TITLE
fix: SheetsStorage retry на edge-5xx (502/504 с HTML-телом) — ключ на HTTP status_code (closes #298)

### DIFF
--- a/src/kinozal_scraper/sheets_storage.py
+++ b/src/kinozal_scraper/sheets_storage.py
@@ -26,7 +26,16 @@ class SchemaError(ValueError):
 
 
 def _is_transient_sheets_error(exc: BaseException) -> bool:
-    return isinstance(exc, gspread.exceptions.APIError) and exc.code in _TRANSIENT_CODES
+    # Key off the authoritative HTTP status (exc.response.status_code), NOT the
+    # JSON-body-derived exc.code: a Google edge/load-balancer 5xx (502/504) ships
+    # an HTML body, so gspread can't parse JSON and sets exc.code = -1 — which
+    # would slip past a code-based filter and crash instead of retrying (#298).
+    # gspread raises APIError only on non-ok responses, so exc.response is always
+    # present and status_code is authoritative.
+    return (
+        isinstance(exc, gspread.exceptions.APIError)
+        and exc.response.status_code in _TRANSIENT_CODES
+    )
 
 
 @runtime_checkable

--- a/tests/test_sheets_storage.py
+++ b/tests/test_sheets_storage.py
@@ -26,13 +26,16 @@ def _api_error(code: int, message: str) -> gspread.exceptions.APIError:
 def _api_error_html(status_code: int, html_text: str) -> gspread.exceptions.APIError:
     """Build a gspread APIError whose body is HTML, not JSON — the edge-5xx case.
 
-    ``resp.json()`` raises → gspread sets ``exc.code = -1``, but the real HTTP
-    ``status_code`` is preserved (Google edge/load-balancer 5xx with an HTML body).
+    Uses a *real* ``requests.Response`` (not a MagicMock) so ``exc.code == -1`` is
+    produced by gspread's own JSON-parse failure, not by a hand-stubbed side_effect
+    — the double can't diverge from real gspread behaviour the way the JSON-body
+    double did (that divergence is exactly why #289's retry fix passed tests yet
+    crashed in prod on a Google edge/load-balancer 5xx with an HTML body).
     """
-    resp = MagicMock(spec=requests.Response)
-    resp.json.side_effect = ValueError("no JSON object could be decoded")
-    resp.text = html_text
+    resp = requests.models.Response()
     resp.status_code = status_code
+    resp._content = html_text.encode("utf-8")
+    resp.headers["Content-Type"] = "text/html; charset=UTF-8"
     return gspread.exceptions.APIError(resp)
 
 

--- a/tests/test_sheets_storage.py
+++ b/tests/test_sheets_storage.py
@@ -12,9 +12,27 @@ from kinozal_scraper.sheets_storage import InMemoryStorage, SchemaError, SheetsS
 
 
 def _api_error(code: int, message: str) -> gspread.exceptions.APIError:
-    """Build a gspread APIError without hitting the network."""
+    """Build a gspread APIError without hitting the network.
+
+    Sets ``status_code`` too — a real APIError always carries the transport
+    status, and the retry filter keys off it (not the JSON-body ``code``).
+    """
     resp = MagicMock(spec=requests.Response)
     resp.json.return_value = {"error": {"code": code, "message": message}}
+    resp.status_code = code
+    return gspread.exceptions.APIError(resp)
+
+
+def _api_error_html(status_code: int, html_text: str) -> gspread.exceptions.APIError:
+    """Build a gspread APIError whose body is HTML, not JSON — the edge-5xx case.
+
+    ``resp.json()`` raises → gspread sets ``exc.code = -1``, but the real HTTP
+    ``status_code`` is preserved (Google edge/load-balancer 5xx with an HTML body).
+    """
+    resp = MagicMock(spec=requests.Response)
+    resp.json.side_effect = ValueError("no JSON object could be decoded")
+    resp.text = html_text
+    resp.status_code = status_code
     return gspread.exceptions.APIError(resp)
 
 
@@ -233,6 +251,42 @@ class TestSheetsStorageRetryTransient(unittest.TestCase):
             storage.append_rows("movies", ROW_HEADERS, [_item("k1").to_row()])
         self.assertEqual(ctx.exception.code, 401)
         self.assertEqual(worksheet.append_rows.call_count, 1)
+
+    # --- edge-5xx with HTML body: exc.code == -1, real status is 5xx (#298) ---
+
+    @patch("tenacity.nap.time.sleep")
+    def test_edge_502_html_body_retries_on_read(self, _sleep: MagicMock) -> None:
+        # Google edge 502 → HTML body → exc.code == -1, but status_code == 502.
+        storage, spreadsheet = self._storage_with_spreadsheet()
+        ws = MagicMock()
+        ws.row_values.side_effect = [
+            _api_error_html(502, "<title>Error 502 (Server Error)!!1</title>"),
+            list(ROW_HEADERS),
+        ]
+        ws.col_values.return_value = ["dedupe_key", "k1"]
+        spreadsheet.worksheet.return_value = ws
+        keys = storage.get_existing_keys("movies")
+        self.assertEqual(ws.row_values.call_count, 2)
+        self.assertIn("k1", keys)
+
+    @patch("tenacity.nap.time.sleep")
+    def test_edge_504_html_body_retries_on_open(self, _sleep: MagicMock) -> None:
+        client = MagicMock(spec=gspread.Client)
+        client.open_by_url.side_effect = [
+            _api_error_html(504, "<title>Error 504 (Gateway Timeout)!!1</title>"),
+            MagicMock(),
+        ]
+        SheetsStorage(client, "https://sheets.example/url")  # must not raise
+        self.assertEqual(client.open_by_url.call_count, 2)
+
+    def test_code_minus1_non_5xx_status_not_retried(self) -> None:
+        # code == -1 (unparseable body) but real status is a client 4xx → fail fast.
+        client = MagicMock(spec=gspread.Client)
+        client.open_by_url.side_effect = [_api_error_html(400, "<html>Bad Request</html>")]
+        with self.assertRaises(gspread.exceptions.APIError) as ctx:
+            SheetsStorage(client, "https://sheets.example/url")
+        self.assertEqual(ctx.exception.code, -1)
+        self.assertEqual(client.open_by_url.call_count, 1)
 
 
 class TestSchemaValidation(unittest.TestCase):


### PR DESCRIPTION
## Что и почему

Scheduled-запуск `28917001189` (2026-07-08) упал с `APIError: [-1]: ... Error 502` на `get_existing_keys → row_values` — **без ретраев**, хотя #289 добавил retry на транзиентные 5xx.

**Root cause:** фильтр `_is_transient_sheets_error` решал по `exc.code`, который gspread берёт из **JSON-тела**. При 502/504 от Google edge/load-balancer тело — HTML, JSON не парсится, gspread ставит `exc.code = -1` → `-1 ∉ _TRANSIENT_CODES` → краш вместо ретрая. Именно тот подкласс 5xx, ради которого retry и добавляли, минул фильтр.

**Fix (Option B, рекомендация architect-review):** фильтруем по авторитетному транспортному статусу `exc.response.status_code`, а не по хрупкому `exc.code`. gspread поднимает `APIError` только на non-ok, поэтому `exc.response` всегда есть и статус авторитетен. Одна строка вместо двухчастного патча сентинела — лечит корень, а не симптом.

## Тесты (RED→GREEN)

- `test_edge_502_html_body_retries_on_read` — code=-1/status=502 → ретрай на read.
- `test_edge_504_html_body_retries_on_open` — то же на open_by_url.
- `test_code_minus1_non_5xx_status_not_retried` — guard: code=-1/status=400 → fail-fast (§IV/§V).
- Ранее покрытые 429/5xx/4xx-пути остаются зелёными (helper `_api_error` теперь несёт `status_code` — достовернее реального APIError).

## Docs

Отдельного doc-PR нет — `testing.md:87` («retry on 429 + 5xx») остаётся истинным, фикс делает его правдой. Правится только inline-коммент `_TRANSIENT_CODES`.

Полный план + architect-review — в #298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)