### PR TITLE
chore: .vscode/settings.json — Pylance на .venv (closes #300)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe"
+}


### PR DESCRIPTION
## Что и почему

В IDE не выбран интерпретатор проекта → Pylance краснит все импорты (`gspread`/`requests`/…). Ложные диагностики попадают и в контекст агента, где могут замаскировать настоящую type-ошибку и жгут токены.

Коммитим `.vscode/settings.json` с **относительным** указателем на venv — переносимо, не машинно-специфично:
```json
{ "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe" }
```

**Не трогает корректность:** авторитетный type-гейт — `mypy` в `ci_check` (покрывает и `tests/`), остаётся источником истины. Pylance — вторичный IDE-канал.

Тривиальный chore, plan-flow пропущен (workflow §8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)