### PR TITLE
test: _make_session на реальных requests.Response + общий _http_doubles (closes #304)

### DIFF
--- a/tests/_gspread_doubles.py
+++ b/tests/_gspread_doubles.py
@@ -19,21 +19,13 @@ from __future__ import annotations
 import json as _json
 
 import gspread.exceptions
-import requests
 
+# make_response lives in the generic _http_doubles module (it builds a plain
+# requests.Response, nothing gspread-specific); re-exported here so callers that
+# already import it from _gspread_doubles keep working.
+from _http_doubles import make_response
 
-def make_response(status_code: int, *, body: bytes, content_type: str) -> requests.Response:
-    """Build a real ``requests.Response`` with the given status/body — no MagicMock.
-
-    Public so integration tests that drive a real gspread request path (feeding
-    the Response through the library itself) reuse the same construction as the
-    error factories below, instead of duplicating it.
-    """
-    resp = requests.models.Response()
-    resp.status_code = status_code
-    resp._content = body
-    resp.headers["Content-Type"] = content_type
-    return resp
+__all__ = ["api_error_html", "api_error_json", "make_response"]
 
 
 def api_error_json(status_code: int, message: str = "") -> gspread.exceptions.APIError:

--- a/tests/_http_doubles.py
+++ b/tests/_http_doubles.py
@@ -1,0 +1,55 @@
+"""Factories for real ``requests.Response`` doubles — never hand-stubbed MagicMocks.
+
+A ``MagicMock`` HTTP response idealises the response in exactly the dimensions that
+bite in prod: ``.headers`` becomes a plain case-*sensitive* ``dict`` (a real
+``Response.headers`` is a case-*insensitive* dict, so ``.get("Retry-After")`` finds
+a lowercase ``retry-after``), and ``.json()`` returns a hand-fed object instead of
+parsing the body. Building a genuine ``Response`` lets the same code paths run as in
+prod. This is the generic sibling of ``_gspread_doubles`` (#298 → #302 → #304).
+"""
+
+from __future__ import annotations
+
+import json as _json
+from collections.abc import Mapping
+
+import requests
+
+
+def make_response(
+    status_code: int,
+    *,
+    body: bytes = b"",
+    content_type: str = "application/octet-stream",
+    headers: Mapping[str, str] | None = None,
+) -> requests.Response:
+    """Build a real ``requests.Response`` with the given status/body/headers.
+
+    ``headers`` land in the real case-insensitive ``Response.headers``, so a
+    lookup by any casing resolves the way it does against a live server.
+    """
+    resp = requests.models.Response()
+    resp.status_code = status_code
+    resp._content = body
+    resp.headers["Content-Type"] = content_type
+    if headers:
+        resp.headers.update(headers)
+    return resp
+
+
+def make_json_response(
+    status_code: int,
+    json_body: object,
+    *,
+    headers: Mapping[str, str] | None = None,
+) -> requests.Response:
+    """A real ``Response`` whose body is ``json_body`` serialised as JSON.
+
+    ``resp.json()`` actually parses it back — no ``.json.return_value`` stubbing.
+    """
+    return make_response(
+        status_code,
+        body=_json.dumps(json_body).encode("utf-8"),
+        content_type="application/json",
+        headers=headers,
+    )

--- a/tests/test_telegram_notifier.py
+++ b/tests/test_telegram_notifier.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
+# HTTP-response doubles are real requests.Response objects — see tests/_http_doubles.py.
+from _http_doubles import make_json_response
+
 from kinozal_scraper.generic_pipeline import (
     NormalizedItem,
     Notification,
@@ -31,16 +34,17 @@ def _item(
 
 
 def _make_session(*responses: tuple) -> MagicMock:
-    """responses: (status_code, json_body, headers_dict) per request."""
+    """responses: (status_code, json_body, headers_dict) per request.
+
+    Each response is a *real* requests.Response (see tests/_http_doubles.py), so
+    resp.json() actually parses the body and resp.headers is the real
+    case-insensitive dict the production code reads Retry-After from.
+    """
     session = MagicMock()
-    mocks = []
-    for status_code, body, headers in responses:
-        r = MagicMock()
-        r.status_code = status_code
-        r.json.return_value = body
-        r.headers = headers
-        mocks.append(r)
-    session.post.side_effect = mocks
+    session.post.side_effect = [
+        make_json_response(status_code, body, headers=headers)
+        for status_code, body, headers in responses
+    ]
     return session
 
 
@@ -152,8 +156,12 @@ class TestTelegramNotifierRetry(unittest.TestCase):
 
     @patch("kinozal_scraper.telegram_notifier.time.sleep")
     def test_429_with_retry_after_header_retries_and_succeeds(self, mock_sleep: MagicMock) -> None:
+        # Lowercase header on purpose: HTTP header names are case-insensitive and a
+        # real Response.headers resolves .get("Retry-After") against "retry-after".
+        # A MagicMock's plain-dict .headers would miss it — this asserts the double
+        # is a real Response, not a hand-stubbed dict (#304).
         session = _make_session(
-            (429, {}, {"Retry-After": "10"}),
+            (429, {}, {"retry-after": "10"}),
             (200, {"ok": True}, {}),
         )
         notifier = _notifier(session)


### PR DESCRIPTION
## Что и почему

Продолжение аудита #302: `_make_session` в telegram-тестах лепил ответы Telegram из `MagicMock` с ручными `.status_code`/`.json.return_value`/`.headers`. Конкретный риск: `.headers` у MagicMock — обычный регистро**зависимый** `dict`, а продакшн читает `resp.headers.get("Retry-After")` — реальный `Response.headers` регистро**не**зависим.

## Сделано

**(1) `tests/_http_doubles.py`** — нейтральный дом `make_response`/`make_json_response` (настоящий `requests.Response`). `_gspread_doubles.make_response` перенесён туда и реэкспортирован — без третьей копии конструирования Response (за дубль цеплялся review #303).

**(2) `_make_session`** строит ответы через `make_json_response`: `resp.json()` реально парсит тело, `.headers` — реальный case-insensitive dict.

**(3)** header-retry тест переведён на **lowercase** `retry-after` — доказывает регистронезависимость. С прежним mock-`dict` он вернул бы default 30 → `sleep(30)` вместо `sleep(10)` → упал бы. Укрепление с зубами, а не косметика.

Testing-only. 61 passed (telegram+sheets), `ci_check` all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)