### PR TITLE
fix: http_fetch ретраит транзиентные HTTP-ответы (403 anti-bot / 429 / 5xx)

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -87,6 +87,11 @@ Choose the cheapest reliable test for each category.
   (Its **retry on transient errors (429 + 5xx)** and **schema validation** *are* tested — see
   `test_sheets_storage.py::TestSheetsStorageRetryTransient` / `TestSchemaValidation` — because
   those are correctness logic mocked at the `gspread.Client` boundary, not internal call order.)
+- `http_fetch` live curl_cffi transport — real network / TLS handshake.
+  (Its **retry on transient HTTP responses (403 anti-bot + 429 + 5xx)** *is* tested — see
+  `test_http_fetch.py::TestFetchRetry`, incl. a reality-anchor over a real curl_cffi
+  `HTTPError` — because that is correctness logic mocked at the `requests.get` boundary,
+  the HTTP-transport sibling of the `SheetsStorage` retry above (#306).)
 - `TelegramChannelSummarizer` / Telethon calls.
 - Any code path that requires live credentials.
 
@@ -199,6 +204,17 @@ work-for-work (goal-function priority (2)).
   header-echo endpoint; the standing gate is the daily cron E2E (a fingerprint regression → 403 on
   posters → §IV-visible next run), same «cron = E2E smoke» doctrine as **A**. Recorded so the
   live-only verification isn't re-opened as a mock-the-network work-for-work test.
+- **M. `http_fetch` retry deliberately scoped to HTTP-status errors only (#306).** The retry layer
+  (`_retry_transient_http`) fires on transient HTTP *responses* (403/429/5xx) but **not** on network
+  errors (`Timeout` / `ConnectionError` — curl_cffi `RequestException` subclasses that never reach
+  `raise_for_status`, so the `isinstance(HTTPError)` predicate skips them by construction). **Accepted**
+  — no reproduced incident (§V: don't retry what wasn't observed), symmetric with the `SheetsStorage`
+  sibling which covers `APIError` status only. The asymmetry «503 retries, a DNS blip crashes the source»
+  is real and conscious; a broadening waits for an actual network-error incident. Separately, the raw
+  `requests.get` calls in `github_popular_pipeline.py` (GitHub API) and `steam_pipeline.py` still have
+  **no** retry — a different transport (stdlib `requests`, not curl_cffi via `http_fetch`) — deferred to
+  a follow-up issue so `_retry_transient_http` can be reused there. Recorded so neither is re-opened as
+  work-for-work.
 
 **Scope-skip (can't run without live credentials) — see [What does NOT get tested](#what-does-not-get-tested-in-this-repo):**
 

--- a/src/kinozal_scraper/http_fetch.py
+++ b/src/kinozal_scraper/http_fetch.py
@@ -6,7 +6,50 @@ Cloudflare-fronted источники не отдавали 403 на JA3/JA4-han
 
 from __future__ import annotations
 
+from typing import Any
+
 from curl_cffi import requests
+from curl_cffi.requests.exceptions import HTTPError
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+# Transient HTTP responses worth retrying rather than crashing the source on the
+# first blip. NOTE the deliberate divergence from sheets_storage._TRANSIENT_CODES
+# (sheets_storage.py:18-21), which EXCLUDES 403 as a fail-fast permission fault:
+# here 403 is an anti-bot / WAF challenge (soldoutticketbox.com, #306) — proven
+# transient (a 200 three minutes later on the same commit), NOT a permission
+# fault — so it IS retried. The two sibling layers treat 403 oppositely on
+# purpose; don't "unify" them.
+_TRANSIENT_HTTP_CODES = frozenset({403, 429, 500, 502, 503, 504})
+
+
+def _is_transient_http_error(exc: BaseException) -> bool:
+    # Key off the authoritative HTTP status carried by the raised HTTPError.
+    # curl_cffi raise_for_status raises HTTPError(msg, 0, response), so exc.response
+    # is the Response and exc.response.status_code is a real int (reality-anchored
+    # in test_http_fetch.py::test_predicate_matches_real_curl_cffi_httperror).
+    return (
+        isinstance(exc, HTTPError)
+        and getattr(exc.response, "status_code", None) in _TRANSIENT_HTTP_CODES
+    )
+
+
+# 4 attempts / max=30 (vs sheets' 5 / max=60): every curl_cffi source runs in the
+# same CI job, so cap total worst-case stall — ~2+4+8≈14 s per source on a full
+# outage, still surfaced red after give-up (reraise=True → §IV visible anomaly).
+_retry_transient_http = retry(
+    retry=retry_if_exception(_is_transient_http_error),
+    stop=stop_after_attempt(4),
+    wait=wait_exponential(multiplier=1, max=30),
+    reraise=True,
+)
+
+
+@_retry_transient_http
+def _get(url: str, **kwargs: Any) -> requests.Response:
+    """Single curl_cffi GET + raise_for_status, retrying transient 403/429/5xx."""
+    resp = requests.get(url, **kwargs)
+    resp.raise_for_status()
+    return resp
 
 
 class NotAnImageError(Exception):
@@ -30,9 +73,7 @@ class NotAnImageError(Exception):
 
 
 def fetch_html(url: str) -> str:
-    resp = requests.get(url, impersonate="chrome", timeout=30)
-    resp.raise_for_status()
-    return resp.text
+    return _get(url, impersonate="chrome", timeout=30).text
 
 
 def fetch_bytes(url: str) -> bytes:
@@ -57,13 +98,15 @@ def fetch_bytes(url: str) -> bytes:
     (`text/html`), not an `image/*` allowlist, since posters live on a long tail
     of uploader hosts that may serve valid images with exotic content-types.
     """
-    resp = requests.get(
+    # NotAnImageError is raised BELOW, after _get returns — outside the retry
+    # wrapper: a 200 text/html anti-hotlink page is a content problem, not a
+    # transient, so it must not be retried.
+    resp = _get(
         url,
         impersonate="chrome",
         timeout=30,
         headers={"Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8"},
     )
-    resp.raise_for_status()
     content_type = resp.headers.get("content-type", "").split(";")[0].strip().lower()
     if content_type == "text/html":
         raise NotAnImageError(url, content_type, resp.content)

--- a/tests/test_http_fetch.py
+++ b/tests/test_http_fetch.py
@@ -1,7 +1,33 @@
 import unittest
 import unittest.mock
 
+from curl_cffi.requests.exceptions import HTTPError
+
 from kinozal_scraper.http_fetch import NotAnImageError, fetch_bytes, fetch_html
+
+
+def _transient_resp(status_code: int) -> unittest.mock.Mock:
+    """A response whose raise_for_status raises a real curl_cffi HTTPError
+    carrying an int .response.status_code — the shape the retry predicate reads."""
+    resp = unittest.mock.Mock()
+    resp.status_code = status_code
+    resp.raise_for_status.side_effect = HTTPError(f"HTTP Error {status_code}", 0, resp)
+    return resp
+
+
+def _ok_html(text: str = "<html>ok</html>") -> unittest.mock.Mock:
+    resp = unittest.mock.Mock()
+    resp.text = text
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _ok_image() -> unittest.mock.Mock:
+    resp = unittest.mock.Mock()
+    resp.content = b"\x89PNG\r\n"
+    resp.headers = {"content-type": "image/png"}
+    resp.raise_for_status.return_value = None
+    return resp
 
 
 class TestFetchHtml(unittest.TestCase):
@@ -124,6 +150,107 @@ class TestFetchBytes(unittest.TestCase):
             self.assertRaises(NotAnImageError),
         ):
             fetch_bytes("https://i126.fastpic.org/big/x.jpg")
+
+
+class TestFetchRetry(unittest.TestCase):
+    """http_fetch retries transient HTTP responses (403 anti-bot / 429 / 5xx)
+    instead of crashing the source on the first blip — the HTTP-transport sibling
+    of the sheets_storage._net retry layer (#298/#299). Prod incident #306: a
+    sporadic WAF 403 from soldoutticketbox.com (proven transient: 200 three
+    minutes later) took down the whole soldout pipeline. backoff neutralised via
+    patching tenacity's sleep."""
+
+    @unittest.mock.patch("tenacity.nap.time.sleep")
+    def test_fetch_html_retries_transient_403_then_succeeds(
+        self, _sleep: unittest.mock.Mock
+    ) -> None:
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get",
+            side_effect=[_transient_resp(403), _ok_html("<html>hi</html>")],
+        ) as mget:
+            result = fetch_html("https://example.com")
+        self.assertEqual(result, "<html>hi</html>")
+        self.assertEqual(mget.call_count, 2)
+
+    @unittest.mock.patch("tenacity.nap.time.sleep")
+    def test_fetch_html_retries_5xx_then_succeeds(self, _sleep: unittest.mock.Mock) -> None:
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get",
+            side_effect=[_transient_resp(502), _ok_html("<html>hi</html>")],
+        ) as mget:
+            result = fetch_html("https://example.com")
+        self.assertEqual(result, "<html>hi</html>")
+        self.assertEqual(mget.call_count, 2)
+
+    @unittest.mock.patch("tenacity.nap.time.sleep")
+    def test_fetch_html_no_retry_on_permanent_404(self, _sleep: unittest.mock.Mock) -> None:
+        # Preservation guard: a permanent 4xx (not in the transient set) must fail
+        # fast — one GET, no retry — so a real config/permission fault surfaces.
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.http_fetch.requests.get", side_effect=[_transient_resp(404)]
+            ) as mget,
+            self.assertRaises(HTTPError),
+        ):
+            fetch_html("https://example.com")
+        self.assertEqual(mget.call_count, 1)
+
+    @unittest.mock.patch("tenacity.nap.time.sleep")
+    def test_fetch_html_gives_up_after_max_attempts_reraises(
+        self, _sleep: unittest.mock.Mock
+    ) -> None:
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.http_fetch.requests.get",
+                side_effect=lambda *a, **k: _transient_resp(503),
+            ) as mget,
+            self.assertRaises(HTTPError),
+        ):
+            fetch_html("https://example.com")
+        self.assertEqual(mget.call_count, 4)
+
+    @unittest.mock.patch("tenacity.nap.time.sleep")
+    def test_fetch_bytes_retries_transient_then_succeeds(self, _sleep: unittest.mock.Mock) -> None:
+        with unittest.mock.patch(
+            "kinozal_scraper.http_fetch.requests.get",
+            side_effect=[_transient_resp(429), _ok_image()],
+        ) as mget:
+            result = fetch_bytes("https://example.com/poster.jpg")
+        self.assertEqual(result, b"\x89PNG\r\n")
+        self.assertEqual(mget.call_count, 2)
+
+    @unittest.mock.patch("tenacity.nap.time.sleep")
+    def test_fetch_bytes_not_an_image_not_retried(self, _sleep: unittest.mock.Mock) -> None:
+        # Preservation guard: a 200 text/html (anti-hotlink viewer, #265) is a
+        # content problem, not a transient — NotAnImageError, exactly one GET.
+        resp = unittest.mock.Mock()
+        resp.content = b"<html></html>"
+        resp.headers = {"content-type": "text/html"}
+        resp.raise_for_status.return_value = None
+        with (
+            unittest.mock.patch(
+                "kinozal_scraper.http_fetch.requests.get", return_value=resp
+            ) as mget,
+            self.assertRaises(NotAnImageError),
+        ):
+            fetch_bytes("https://i126.fastpic.org/big/x.jpg")
+        self.assertEqual(mget.call_count, 1)
+
+    def test_predicate_matches_real_curl_cffi_httperror(self) -> None:
+        # Reality-anchor (SHOULD-FIX #1, sibling of TestGspreadRetryIntegrationAnchor):
+        # the predicate must fire on a HTTPError produced by REAL curl_cffi
+        # raise_for_status, not a hand-built Mock — otherwise it can silently
+        # mis-read the attr path and 403 crashes prod again (the #298 class).
+        from curl_cffi.requests.models import Response
+
+        from kinozal_scraper.http_fetch import _is_transient_http_error
+
+        resp = Response()
+        resp.status_code = 403
+        resp.ok = False
+        with self.assertRaises(HTTPError) as ctx:
+            resp.raise_for_status()
+        self.assertTrue(_is_transient_http_error(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Что и почему

`fetch_html`/`fetch_bytes` делали единичный GET + `raise_for_status()` **без ретрая** — любой не-2xx роняет источник с первой попытки.

**Прод-инцидент #306 (2026-07-09):** ручной прогон `soldout_pipeline` упал на `HTTP Error 403` при `fetch_html(SOLDOUT_URL)`. **Доказанно транзиентный**: cron на том же коммите `e3801f2` через 3 минуты отдал 200. Причина — anti-bot/WAF-challenge soldoutticketbox.com (curl_cffi `impersonate` из #217 снимает *систематический* 403 на TLS-фингерпринт, но не *спорадический* WAF).

Прямой HTTP-транспортный сиблинг закрытого #298/#299 (retry-слой `sheets_storage._net`).

## Как

- `_retry_transient_http` — tenacity `@retry`, 4 попытки, exp-backoff `max=30`, `reraise=True` (после исчерпания HTTPError всплывает → red CI → §IV видимая аномалия, не silent-skip).
- `_is_transient_http_error` ключуется на `exc.response.status_code`, набор `{403, 429, 500, 502, 503, 504}`.
- **403 включён осознанно** (anti-bot ≠ permission-fault) — комментарий cross-ref'ит обратное решение в `sheets_storage` (там 403 fail-fast), чтобы будущий «унификатор» не сломал кейс.
- `NotAnImageError` (200 text/html, #265) бросается **вне** retry — контент-проблема, не транзиент.

## Тесты

`tests/test_http_fetch.py::TestFetchRetry` (7 тестов, backoff нейтрализован `@patch tenacity.nap.time.sleep`): retry-then-success для 403/5xx/429, no-retry на 404, give-up-reraise (ровно 4 попытки), not_an_image не ретраится, и **reality-anchor** на **настоящем** curl_cffi `HTTPError` (симметрично `TestGspreadRetryIntegrationAnchor` — гарантия, что предикат не идеализирован, класс бага #298).

## Out of scope (ledger `testing.md#M`)

- Сетевые `Timeout`/`ConnectionError` — нет repro (§V), симметрично sheets (`APIError`-only).
- Raw `requests.get` без retry в `github_popular_pipeline`/`steam_pipeline` (stdlib requests) — follow-up.
- Изоляция источников (#148/#149) и failure-alert (#245/#246) — уже работают (проверено на инциденте).

Architect-review вплетён в план (issue #306): BLOCKING нет, все SHOULD-FIX учтены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #306