### PR TITLE
deps: bump soupsieve to 2.8.4 (CVE-2026-49476/49477)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -167,7 +167,7 @@ sniffio==1.3.1
     # via trio
 sortedcontainers==2.4.0
     # via trio
-soupsieve==2.8.3
+soupsieve==2.8.4
     # via
     #   -r requirements.in
     #   beautifulsoup4


### PR DESCRIPTION
## Что и зачем
`pip-audit` (runtime, в `scripts/ci_check.py`) флагует **soupsieve 2.8.3** — `CVE-2026-49476`, `CVE-2026-49477`; fix-версия **2.8.4**. Свежий CVE роняет `ci_check` → `.githooks/pre-push` блокирует любой push (не только связанный). Closes #311.

## Изменение
`pip-compile --upgrade-package soupsieve` → `requirements.txt`: `soupsieve==2.8.3` → `2.8.4`. Точечный bump, один пин, остальное не тронуто (workflow #7). Тривиальный dep-bump — без `/plan` (workflow #8). Прецедент — #103 (idna CVE).

## Проверка
`python scripts/ci_check.py` зелёный (pip-audit: «No known vulnerabilities found»). Красные локальные прогоны — предсуществующая спорадическая флак-нестабильность pip-audit/pytest (сеть/AV-скан, CLAUDE.md), не связана с этим bump'ом; pre-push прошёл зелёным.

🤖 Generated with [Claude Code](https://claude.com/claude-code)