### PR TITLE
feat: per-source failure alerts для скрейпинг-пайплайнов

### DIFF
--- a/docs/architecture/ci.md
+++ b/docs/architecture/ci.md
@@ -364,6 +364,24 @@ guarded statically by `tests/test_workflow_isolation.py::TestPipelineStepIsolati
 so a newly-added source is automatically held to it — a hand-maintained list would let the
 next source slip back into the cascade.
 
+**Readable per-source alert (#310).** A failed scraper step used to reach the operator only as
+the generic `Send fallback failure alert` (`⚠️ … run failed: <url>`) — visible but not
+*actionable*: which source, which error class lived only in the CI log (precedent: run
+29224080924, soldout 403 required a log dig). Each scraper `__main__` now calls
+`alerting.report_failures(notifier, results)` before `sys.exit(1)`: it sends a readable
+`source_id: <error>` breakdown to Telegram (reusing `PipelineResult.errors`) and, **on
+successful delivery only**, writes the job-global marker `.run/technical_alert_sent`. That
+marker gates the `Send fallback failure alert` step (`hashFiles(...) == ''`), so a delivered
+rich alert suppresses the generic curl one.
+
+The marker is **job-global**: it means *"≥1 rich alert delivered this run"*, not "this step
+delivered". So the curl fallback stays the net only for the **first** undelivered alert (or a
+crash *before* `report_failures` — import error, etc.). If a **second** step's alert delivery
+fails after an earlier one already set the marker, the backstop is the **red run + logs**
+(§III), not curl — a consciously accepted gap (no per-step marker infra; see #310 Out of
+scope). `telegram_summarizer` keeps its own richer `deliver_results` alert path; `report_failures`
+and the marker helpers share one canonical home in `alerting.py`.
+
 ## Environment variables
 
 ### Shared across pipelines

--- a/docs/architecture/project-map.md
+++ b/docs/architecture/project-map.md
@@ -168,7 +168,7 @@ orientation, которого в per-file docstring нет.
 |---|---|---|
 | Слой пайплайна (ядро + контракты) | `src/kinozal_scraper/generic_pipeline.py`, `src/kinozal_scraper/pipeline_config.py` | `pipeline.md` (config → `principles.md §VI`) |
 | Extraction/нормализация по источникам | `src/kinozal_scraper/kinozal_pipeline.py`, `src/kinozal_scraper/steam_pipeline.py`, `src/kinozal_scraper/soldout_pipeline.py`, `src/kinozal_scraper/github_popular_pipeline.py`, `src/kinozal_scraper/github_trending_pipeline.py` | `pipeline.md` |
-| Boundaries (Protocol-границы наружу) | `src/kinozal_scraper/sheets_storage.py` (storage), `src/kinozal_scraper/telegram_notifier.py` / `src/kinozal_scraper/telegram_summarizer.py` (notify), `src/kinozal_scraper/gemini_enricher.py` / `src/kinozal_scraper/TelegramChannelSummarizer.py` (Gemini), `src/kinozal_scraper/http_fetch.py` (единый HTML-fetch: curl_cffi + impersonate, обходит Cloudflare TLS-фингерпринт — #217) | `storage.md` · `runtime.md` · `gemini.md` |
+| Boundaries (Protocol-границы наружу) | `src/kinozal_scraper/sheets_storage.py` (storage), `src/kinozal_scraper/telegram_notifier.py` / `src/kinozal_scraper/telegram_summarizer.py` (notify) / `src/kinozal_scraper/alerting.py` (канонический дом operator-alerting: маркер `.run/technical_alert_sent` + `report_failures` per-source failure-алерт, #310), `src/kinozal_scraper/gemini_enricher.py` / `src/kinozal_scraper/TelegramChannelSummarizer.py` (Gemini), `src/kinozal_scraper/http_fetch.py` (единый HTML-fetch: curl_cffi + impersonate, обходит Cloudflare TLS-фингерпринт — #217) | `storage.md` · `runtime.md` · `gemini.md` |
 | Утилиты | `src/kinozal_scraper/youtube.py`, `src/kinozal_scraper/text_utils.py`, `src/kinozal_scraper/crypto.py` | — |
 
 ---

--- a/src/kinozal_scraper/alerting.py
+++ b/src/kinozal_scraper/alerting.py
@@ -1,0 +1,82 @@
+"""Operator-facing failure alerting — канонический дом (#310).
+
+Собирает воедино то, что раньше жило только в `telegram_summarizer`: маркер
+`.run/technical_alert_sent` (гейтит generic curl-fallback в `run-script.yml`),
+доставку текста алерта и — новое — читаемый per-source алерт для скрейпинг-
+пайплайнов (`source_id: <ошибка>` вместо немого «run failed + link»).
+
+**Топология маркера — job-global.** Все скрейперы + summarizer идут
+последовательными шагами одного GH-job'а с общим workspace; единственный
+потребитель маркера — guard curl-шага `hashFiles(...) == ''`. Поэтому маркер
+означает «≥1 богатый алерт доставлен за этот run», а не «этот шаг доставил».
+При провале доставки 2-го+ алерта backstop — красный run + логи (§III), не curl
+(architect-review B1). Никакой per-step marker-инфры сознательно нет.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from kinozal_scraper.generic_pipeline import PipelineResult
+
+logger = logging.getLogger(__name__)
+
+_TECH_ALERT_MARKER = ".run/technical_alert_sent"
+
+
+def mark_technical_alert_sent(path: str | None = None) -> None:
+    marker_value = path if path is not None else os.getenv("TECH_ALERT_MARKER")
+    marker = Path(marker_value or _TECH_ALERT_MARKER)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("1", encoding="utf-8")
+
+
+def send_required_text(notifier: Any, text: str) -> bool:
+    ok = bool(notifier.send_text(text))
+    if not ok:
+        logger.error("Telegram delivery failed")
+    return ok
+
+
+def format_pipeline_failures(results: list[PipelineResult]) -> str:
+    """Читаемый per-source алерт: `source_id: <первая ошибка>` по каждому failed.
+
+    Сиблинг `telegram_summarizer.format_technical_alert`, но по `PipelineResult`
+    (`source_id` + `errors`), а не `ChannelProcessResult`. HTML-эскейп — Telegram
+    `parse_mode=HTML` (иначе `<`/`&` в ошибке ломают parser).
+    """
+    failed = [r for r in results if not r.ok]
+    lines = [
+        "⚠️ Ошибка пайплайна",
+        "Источник упал — часть данных не собрана / не доставлена.",
+        "",
+    ]
+    for result in failed[:10]:
+        first = result.errors[0] if result.errors else "unknown error"
+        lines.append(f"- {_html.escape(result.source_id)}: {_html.escape(first)}")
+    if len(failed) > 10:
+        lines.append(f"... и ещё {len(failed) - 10} failure(s)")
+    return "\n".join(lines)
+
+
+def report_failures(notifier: Any, results: list[PipelineResult]) -> bool:
+    """Отправить читаемый алерт по failed-результатам; вернуть, были ли сбои.
+
+    Caller делает `if report_failures(...): sys.exit(1)` — §IV exit-код сохранён.
+    Маркер ставится ТОЛЬКО при успешной доставке (зеркалит `deliver_results`):
+    при провале `send_text` маркер не пишется, curl-fallback остаётся сетью для
+    этого первого недоставленного алерта, а сам сбой виден в ERROR-логе.
+    """
+    failed = [r for r in results if not r.ok]
+    if not failed:
+        return False
+    if send_required_text(notifier, format_pipeline_failures(results)):
+        try:
+            mark_technical_alert_sent()
+        except Exception as exc:  # noqa: BLE001 — marker write failure must not crash the alert path
+            logger.exception("Could not write technical alert marker: %s", exc)
+    return True

--- a/src/kinozal_scraper/github_popular_pipeline.py
+++ b/src/kinozal_scraper/github_popular_pipeline.py
@@ -201,5 +201,7 @@ if __name__ == "__main__":
 
     prod_results = run_github_popular_pipeline(prod_storage, prod_notifier, enricher=prod_enricher)
 
-    if any(not r.ok for r in prod_results):
+    from kinozal_scraper.alerting import report_failures
+
+    if report_failures(prod_notifier, prod_results):
         sys.exit(1)

--- a/src/kinozal_scraper/github_trending_pipeline.py
+++ b/src/kinozal_scraper/github_trending_pipeline.py
@@ -277,5 +277,7 @@ if __name__ == "__main__":
         sources_config=sources_config,
     )
 
-    if any(not r.ok for r in prod_results):
+    from kinozal_scraper.alerting import report_failures
+
+    if report_failures(prod_notifier, prod_results):
         sys.exit(1)

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -635,5 +635,7 @@ if __name__ == "__main__":
     youtube = Youtube()
     prod_results = run_kinozal_pipeline(storage, notifier, youtube, kinozal=kinozal)
 
-    if any(not r.ok for r in prod_results):
+    from kinozal_scraper.alerting import report_failures
+
+    if report_failures(notifier, prod_results):
         sys.exit(1)

--- a/src/kinozal_scraper/soldout_pipeline.py
+++ b/src/kinozal_scraper/soldout_pipeline.py
@@ -129,5 +129,7 @@ if __name__ == "__main__":
     prod_notifier = TelegramNotifier(bot_token=bot_token, chat_id=chat_id)
     prod_results = run_soldout_pipeline(prod_storage, prod_notifier)
 
-    if any(not r.ok for r in prod_results):
+    from kinozal_scraper.alerting import report_failures
+
+    if report_failures(prod_notifier, prod_results):
         sys.exit(1)

--- a/src/kinozal_scraper/steam_pipeline.py
+++ b/src/kinozal_scraper/steam_pipeline.py
@@ -320,5 +320,7 @@ if __name__ == "__main__":
         prod_storage, prod_notifier, sources_config=prod_config, enricher=prod_enricher
     )
 
-    if any(not r.ok for r in prod_results):
+    from kinozal_scraper.alerting import report_failures
+
+    if report_failures(prod_notifier, prod_results):
         sys.exit(1)

--- a/src/kinozal_scraper/telegram_notifier.py
+++ b/src/kinozal_scraper/telegram_notifier.py
@@ -32,6 +32,8 @@ class Notifier(Protocol):
         self, notifications: list[Notification]
     ) -> tuple[list[Notification], list[Notification]]: ...
 
+    def send_text(self, text: str) -> bool: ...
+
 
 class TelegramNotifier:
     def __init__(
@@ -162,12 +164,14 @@ class TelegramNotifier:
 
 
 class InMemoryNotifier:
-    """Test double. Контролируемые сбои через fail_ids."""
+    """Test double. Контролируемые сбои через fail_ids (send_items) / fail_text (send_text)."""
 
-    def __init__(self, fail_ids: set[str] | None = None) -> None:
+    def __init__(self, fail_ids: set[str] | None = None, fail_text: bool = False) -> None:
         self.sent: list[Notification] = []
         self.failed: list[Notification] = []
+        self.texts: list[str] = []
         self._fail_ids: set[str] = fail_ids or set()
+        self._fail_text = fail_text
 
     def send_items(
         self, notifications: list[Notification]
@@ -178,3 +182,9 @@ class InMemoryNotifier:
             else:
                 self.sent.append(notif)
         return list(self.sent), list(self.failed)
+
+    def send_text(self, text: str) -> bool:
+        if self._fail_text:
+            return False
+        self.texts.append(text)
+        return True

--- a/src/kinozal_scraper/telegram_summarizer.py
+++ b/src/kinozal_scraper/telegram_summarizer.py
@@ -5,14 +5,12 @@ from __future__ import annotations
 import html as _html
 import logging
 import os
-from pathlib import Path
 from typing import Any
 
+from kinozal_scraper.alerting import mark_technical_alert_sent, send_required_text
 from kinozal_scraper.TelegramChannelSummarizer import ChannelProcessResult, ChannelSummary
 
 logger = logging.getLogger(__name__)
-
-_TECH_ALERT_MARKER = ".run/technical_alert_sent"
 
 
 def format_summary_message(summary: ChannelSummary) -> str:
@@ -45,20 +43,6 @@ def format_technical_alert(results: list[ChannelProcessResult]) -> str:
     if len(failed) > 10:
         lines.append(f"... и ещё {len(failed) - 10} failure(s)")
     return "\n".join(lines)
-
-
-def mark_technical_alert_sent(path: str | None = None) -> None:
-    marker_value = path if path is not None else os.getenv("TECH_ALERT_MARKER")
-    marker = Path(marker_value or _TECH_ALERT_MARKER)
-    marker.parent.mkdir(parents=True, exist_ok=True)
-    marker.write_text("1", encoding="utf-8")
-
-
-def send_required_text(notifier: Any, text: str) -> bool:
-    ok = bool(notifier.send_text(text))
-    if not ok:
-        logger.error("Telegram delivery failed")
-    return ok
 
 
 def deliver_results(notifier: Any, results: list[ChannelProcessResult]) -> int:

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -1,0 +1,93 @@
+"""Tests for alerting.py — operator-facing per-source failure alerts (#310).
+
+`report_failures` surfaces `PipelineResult` failures to Telegram with source_id +
+error class (§IV: visible AND actionable), reusing the technical-alert marker that
+gates the workflow-level curl fallback. The marker is job-global — it means "at
+least one rich alert delivered this run"; on a *second* send-failure the backstop
+is the red run + logs (§III), NOT the curl step (architect-review B1, issue #310).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kinozal_scraper.alerting import format_pipeline_failures, report_failures
+
+from kinozal_scraper.generic_pipeline import PipelineResult
+from kinozal_scraper.telegram_notifier import InMemoryNotifier
+
+
+def _ok(source_id: str) -> PipelineResult:
+    return PipelineResult(source_id=source_id)
+
+
+def _failed(source_id: str, error: str) -> PipelineResult:
+    result = PipelineResult(source_id=source_id)
+    result.errors.append(error)
+    return result
+
+
+class TestFormatPipelineFailures:
+    def test_lists_source_id_and_first_error(self) -> None:
+        text = format_pipeline_failures(
+            [_ok("steam"), _failed("soldout", "fetch failed: HTTP Error 403")]
+        )
+        assert "soldout" in text
+        assert "fetch failed: HTTP Error 403" in text
+        assert "steam" not in text  # ok source is not listed
+
+    def test_truncates_beyond_ten(self) -> None:
+        results = [_failed(f"src{i}", f"err{i}") for i in range(12)]
+        text = format_pipeline_failures(results)
+        assert "src11" not in text  # 12th failure not individually listed
+        assert "ещё 2" in text  # 12 - 10
+
+    def test_escapes_html_in_error(self) -> None:
+        text = format_pipeline_failures([_failed("s", "<b> & </b>")])
+        assert "&lt;b&gt;" in text
+        assert "&amp;" in text
+        assert "<b>" not in text
+
+
+class TestReportFailures:
+    def test_all_ok_no_send_no_mark_returns_false(self, tmp_path, monkeypatch) -> None:
+        marker = tmp_path / "technical_alert_sent"
+        monkeypatch.setenv("TECH_ALERT_MARKER", str(marker))
+        notifier = InMemoryNotifier()
+
+        assert report_failures(notifier, [_ok("a"), _ok("b")]) is False
+        assert notifier.texts == []
+        assert not marker.exists()
+
+    def test_failure_sends_alert_marks_returns_true(self, tmp_path, monkeypatch) -> None:
+        marker = tmp_path / "technical_alert_sent"
+        monkeypatch.setenv("TECH_ALERT_MARKER", str(marker))
+        notifier = InMemoryNotifier()
+
+        assert report_failures(notifier, [_ok("a"), _failed("soldout", "boom")]) is True
+        assert len(notifier.texts) == 1
+        assert "soldout" in notifier.texts[0]
+        assert marker.exists()
+
+    def test_send_failure_does_not_mark_returns_true(self, tmp_path, monkeypatch, caplog) -> None:
+        marker = tmp_path / "technical_alert_sent"
+        monkeypatch.setenv("TECH_ALERT_MARKER", str(marker))
+        notifier = InMemoryNotifier(fail_text=True)
+
+        with caplog.at_level(logging.ERROR):
+            assert report_failures(notifier, [_failed("soldout", "boom")]) is True
+
+        # Delivery failed → marker NOT written, so the curl fallback stays as the
+        # net for this first failure; the failure is still surfaced (ERROR log).
+        assert not marker.exists()
+        assert any(record.levelno >= logging.ERROR for record in caplog.records)
+
+    def test_marker_write_failure_does_not_crash(self, tmp_path, monkeypatch) -> None:
+        # Parent of the marker path is a regular file → mkdir/write raises; the
+        # alert path must swallow it (logged), never propagate.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("x", encoding="utf-8")
+        monkeypatch.setenv("TECH_ALERT_MARKER", str(blocker / "marker"))
+        notifier = InMemoryNotifier()
+
+        assert report_failures(notifier, [_failed("soldout", "boom")]) is True

--- a/tests/test_alerting.py
+++ b/tests/test_alerting.py
@@ -10,9 +10,11 @@ is the red run + logs (§III), NOT the curl step (architect-review B1, issue #31
 from __future__ import annotations
 
 import logging
+from pathlib import Path
+
+import pytest
 
 from kinozal_scraper.alerting import format_pipeline_failures, report_failures
-
 from kinozal_scraper.generic_pipeline import PipelineResult
 from kinozal_scraper.telegram_notifier import InMemoryNotifier
 
@@ -50,7 +52,9 @@ class TestFormatPipelineFailures:
 
 
 class TestReportFailures:
-    def test_all_ok_no_send_no_mark_returns_false(self, tmp_path, monkeypatch) -> None:
+    def test_all_ok_no_send_no_mark_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         marker = tmp_path / "technical_alert_sent"
         monkeypatch.setenv("TECH_ALERT_MARKER", str(marker))
         notifier = InMemoryNotifier()
@@ -59,7 +63,9 @@ class TestReportFailures:
         assert notifier.texts == []
         assert not marker.exists()
 
-    def test_failure_sends_alert_marks_returns_true(self, tmp_path, monkeypatch) -> None:
+    def test_failure_sends_alert_marks_returns_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         marker = tmp_path / "technical_alert_sent"
         monkeypatch.setenv("TECH_ALERT_MARKER", str(marker))
         notifier = InMemoryNotifier()
@@ -69,7 +75,12 @@ class TestReportFailures:
         assert "soldout" in notifier.texts[0]
         assert marker.exists()
 
-    def test_send_failure_does_not_mark_returns_true(self, tmp_path, monkeypatch, caplog) -> None:
+    def test_send_failure_does_not_mark_returns_true(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         marker = tmp_path / "technical_alert_sent"
         monkeypatch.setenv("TECH_ALERT_MARKER", str(marker))
         notifier = InMemoryNotifier(fail_text=True)
@@ -82,7 +93,9 @@ class TestReportFailures:
         assert not marker.exists()
         assert any(record.levelno >= logging.ERROR for record in caplog.records)
 
-    def test_marker_write_failure_does_not_crash(self, tmp_path, monkeypatch) -> None:
+    def test_marker_write_failure_does_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         # Parent of the marker path is a regular file → mkdir/write raises; the
         # alert path must swallow it (logged), never propagate.
         blocker = tmp_path / "blocker"

--- a/tests/test_alerting_wiring.py
+++ b/tests/test_alerting_wiring.py
@@ -1,0 +1,37 @@
+"""Anti-drift: every scraper __main__ must gate sys.exit(1) on report_failures (#310).
+
+Mirrors tests/test_settings_hooks.py — a static source scan, no imports/network.
+A bare substring check on `report_failures(` would pass even if a scraper called it
+but dropped the `sys.exit(1)`, silently regressing the §IV non-zero-exit invariant;
+so we assert the full `if report_failures(...): sys.exit(1)` shape (architect S2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[1]
+_SRC = _REPO / "src" / "kinozal_scraper"
+
+_SCRAPERS = [
+    "soldout_pipeline.py",
+    "kinozal_pipeline.py",
+    "steam_pipeline.py",
+    "github_popular_pipeline.py",
+    "github_trending_pipeline.py",
+]
+
+_GUARD = re.compile(r"if\s+report_failures\([^\n]*\):\s*\n\s*sys\.exit\(1\)")
+
+
+class TestScrapersReportFailures:
+    @pytest.mark.parametrize("module", _SCRAPERS)
+    def test_all_five_scrapers_guard_exit_on_report_failures(self, module: str) -> None:
+        source = (_SRC / module).read_text(encoding="utf-8")
+        assert _GUARD.search(source), (
+            f"{module} __main__ must gate `sys.exit(1)` on `report_failures(...)` "
+            "(anti-drift for the §IV non-zero-exit invariant)"
+        )

--- a/tests/test_telegram_notifier.py
+++ b/tests/test_telegram_notifier.py
@@ -356,6 +356,15 @@ class TestInMemoryNotifier(unittest.TestCase):
         self.assertEqual(sent, [n1])
         self.assertEqual(failed, [n2])
 
+    def test_send_text_records_and_returns_true(self) -> None:
+        notifier = InMemoryNotifier()
+        self.assertTrue(notifier.send_text("hello"))
+        self.assertEqual(notifier.texts, ["hello"])
+
+    def test_send_text_fail_mode_returns_false(self) -> None:
+        notifier = InMemoryNotifier(fail_text=True)
+        self.assertFalse(notifier.send_text("hello"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Скрейпинг-пайплайны теперь шлют оператору **читаемый per-source алерт** при сбое, а не только generic «run failed + ссылка». Новый канонический дом операторского алертинга — `alerting.py`: сюда переехали shared-хелперы (`_TECH_ALERT_MARKER`, `mark_technical_alert_sent`, `send_required_text`) из `telegram_summarizer.py` и добавлены `format_pipeline_failures` (source_id + класс ошибки, HTML-escape, truncate >10) и `report_failures`. Все 5 скрейперов (`soldout`, `kinozal`, `steam`, `github_popular`, `github_trending`) в `__main__` заменили немой `if any(not r.ok): sys.exit(1)` на `if report_failures(notifier, prod_results): sys.exit(1)`. Мотив: сегодняшний упавший ран (soldout WAF 403) в Telegram выглядел как безликий «упало» — по алерту нельзя было понять, что именно и почему (§IV: видимо **и** actionable). Совпало с issue `## Implementation outline`.

Closes #310

## Test plan

- [x] `python scripts/ci_check.py` — green локально (552 passed, mypy/ruff/import-linter/pip-audit ×2 clean)
- [x] `tests/test_alerting.py` — `TestFormatPipelineFailures` (3) + `TestReportFailures` (4: all-ok-no-send, failure-sends-marks, send-failure-no-mark, marker-write-failure-no-crash)
- [x] `tests/test_alerting_wiring.py` — static anti-drift: все 5 скрейперов несут `if report_failures(...): sys.exit(1)`
- [x] `tests/test_telegram_notifier.py` — `send_text` на Protocol + `InMemoryNotifier(fail_text=...)`
- [ ] CI на PR — green

## Risk & Rollback

- **Blast-radius**: изолировано в notify-boundary. Продуктовая логика пайплайнов не тронута — только exit-путь `__main__` + переезд shared-хелперов. Маркер `.run/technical_alert_sent` — тот же, что гейтит workflow-level curl fallback; семантика job-global («≥1 rich-алерт за ран») сохранена (architect B1).
- **Rollback**: чистый `git revert` — необратимых эффектов нет (алерты идут в тот же Telegram-канал, что и раньше; Sheets-дедуп не задет).
- **Мониторинг**: ближайший крон-ран `run-script.yml` — при сбое источника ждём в Telegram строку `⚠️ Ошибка пайплайна` с source_id, а не generic-фолбэк.
