### PR TITLE
feat: оригинальное название в YouTube-запрос трейлера + §IV видимый маркер

### DIFF
--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -78,8 +78,8 @@ Telegram HTML message. Available template variables:
 | `{title}` | plain escaped title |
 | `{title_link}` | `<a href="{url}">{title}</a>` — clickable title linking to the source page |
 | `{url}` | raw URL of the item page |
-| `{trailer_url}` | raw YouTube trailer URL |
-| `{trailer_link}` | `<a href="{trailer_url}">Trailer</a>` — clickable "Trailer" word; empty if no trailer |
+| `{trailer_url}` | raw YouTube trailer URL, or a §IV miss/failure marker (see below) |
+| `{trailer_link}` | `<a href="{trailer_url}">Trailer</a>` — clickable "Trailer" word for an http(s) URL; a non-http value (a §IV marker `🎬 трейлер не найден` on a clean miss / `⚠️ трейлер: ошибка поиска` on a lookup failure, #138) renders as visible escaped text; empty only when `trailer_url` is unset (non-kinozal sources) |
 | `{description}` | plain escaped description |
 | `{metric}` | numeric metric (stars, players, etc.) |
 | `{image_url}` | raw image URL |

--- a/src/kinozal_scraper/generic_pipeline.py
+++ b/src/kinozal_scraper/generic_pipeline.py
@@ -253,11 +253,17 @@ def build_notification(item: NormalizedItem, template: str) -> Notification:
         if item.url and item.url.startswith(("http://", "https://"))
         else _html.escape(item.title)
     )
-    trailer_link = (
-        _html_link(item.trailer_url, "Trailer")
-        if item.trailer_url and item.trailer_url.startswith(("http://", "https://"))
-        else ""
-    )
+    # An http(s) trailer_url renders a clickable "Trailer" word; a non-http,
+    # non-empty value is a §IV miss/failure marker (#138) and reaches the user as
+    # visible escaped text, not a collapsed empty line. Empty → empty (sources
+    # that never enrich a trailer are unaffected). The renderer stays source-
+    # agnostic: it knows "http vs marker vs none", not "kinozal markers".
+    if item.trailer_url and item.trailer_url.startswith(("http://", "https://")):
+        trailer_link = _html_link(item.trailer_url, "Trailer")
+    elif item.trailer_url:
+        trailer_link = _html.escape(item.trailer_url)
+    else:
+        trailer_link = ""
     values: dict[str, Any] = {
         "title": item.title,
         "title_link": title_link,

--- a/src/kinozal_scraper/kinozal_pipeline.py
+++ b/src/kinozal_scraper/kinozal_pipeline.py
@@ -24,6 +24,7 @@ from kinozal_scraper.kinozal_auth import fetch_authenticated, login
 from kinozal_scraper.pipeline_config import load_sources_config
 from kinozal_scraper.sheets_storage import Storage
 from kinozal_scraper.telegram_notifier import Notifier, TelegramNotifier
+from kinozal_scraper.text_utils import original_title
 
 logger = logging.getLogger(__name__)
 
@@ -347,22 +348,41 @@ def _normalize_items(items: list[NormalizedItem]) -> list[NormalizedItem]:
     return result
 
 
-def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
-    """Look up a YouTube trailer URL. Returns '' on any failure.
+# §IV visible markers (#138): a trailer miss/failure must reach the user as a
+# legible line, never a silent empty `{trailer_link}`. Distinct text + log level
+# let the user tell "no trailer exists" from "lookup broke", and keep the WARNING
+# dev-tripwire firing only on real anomalies (a clean miss is expected).
+_TRAILER_MISS_MARKER = "🎬 трейлер не найден"
+_TRAILER_ERROR_MARKER = "⚠️ трейлер: ошибка поиска"
 
-    Expects item.title to already be cleaned (no ' / ' separators).
-    Year is read from item.raw['kinozal_raw_title'] (the original @title
-    attribute) because the clean title may have had the year stripped.
+
+def enrich_with_trailer(item: NormalizedItem, youtube: Any) -> str:
+    """Look up a YouTube trailer URL, or return a visible §IV marker (#138).
+
+    Queries YouTube with the *original* foreign title (2nd ` / `-segment of the
+    raw @title) when present — a far better match than the localised RU title —
+    falling back to the clean RU title otherwise. Year is read from
+    item.raw['kinozal_raw_title'] (the original @title) because the clean title
+    may have had the year stripped, and feeds `title_year_matches`.
+
+    On a clean miss (API OK, 0 results) returns `_TRAILER_MISS_MARKER` + INFO log;
+    on a lookup exception returns `_TRAILER_ERROR_MARKER` + WARNING log (with
+    traceback). Either way the item is still notified — no silent empty string.
     """
+    clean = item.title.split("(")[0].strip()
+    raw_for_year = item.raw.get("kinozal_raw_title", item.dedupe_key)
+    year_match = re.search(r"\b(20\d{2})\b", raw_for_year)
+    year = int(year_match.group(1)) if year_match else None
+    query = original_title(raw_for_year) or clean
     try:
-        clean = item.title.split("(")[0].strip()
-        raw_for_year = item.raw.get("kinozal_raw_title", item.dedupe_key)
-        year_match = re.search(r"\b(20\d{2})\b", raw_for_year)
-        year = int(year_match.group(1)) if year_match else None
-        return youtube.get_trailer_url(clean, year=year) or ""
-    except Exception as exc:  # noqa: BLE001 — trailer lookup degrades to no-trailer, item still notified
-        logger.exception("trailer lookup failed for %r: %s", item.title, exc)
-        return ""
+        url: str = youtube.get_trailer_url(query, year=year)
+    except Exception as exc:  # noqa: BLE001 — lookup failure degrades to a visible marker, item still notified
+        logger.warning("trailer lookup failed for %r: %s", item.title, exc, exc_info=True)
+        return _TRAILER_ERROR_MARKER
+    if url:
+        return url
+    logger.info("no trailer found for %r", item.title)
+    return _TRAILER_MISS_MARKER
 
 
 def _split_by_excluded_genre(

--- a/src/kinozal_scraper/text_utils.py
+++ b/src/kinozal_scraper/text_utils.py
@@ -9,3 +9,26 @@ def title_year_matches(title: str, film_year: int) -> bool:
     """Return False if the video title explicitly mentions a year other than film_year."""
     title_years = {int(m) for m in re.findall(r"\b((?:19|20)\d{2})\b", title)}
     return not title_years or film_year in title_years
+
+
+def original_title(raw: str) -> str:
+    """Extract the original (foreign) title from a raw kinozal `@title` (#138).
+
+    Kinozal encodes titles as `RU / Original / Year / Format`; the original title
+    is the second ` / `-segment when present. It yields far better YouTube trailer
+    matches than the transliterated/localised RU title, so the caller prefers it.
+
+    Returns '' when there is no distinct original segment — either the raw has no
+    ` / ` separator (`Дюна`) or the second segment is just the year
+    (`Film One / 2024 / BDRip`, i.e. `Title / Year / Format`) — so the caller
+    falls back to the clean RU title. The year guard uses the same `(?:19|20)\\d{2}`
+    shape as `title_year_matches`; a numeric-only original (e.g. `2001`) is
+    consciously swallowed as a year (rare edge, see #138 Out of scope).
+    """
+    parts = [p.strip() for p in raw.split(" / ")]
+    if len(parts) < 2:
+        return ""
+    candidate = parts[1]
+    if re.fullmatch(r"(?:19|20)\d{2}", candidate):
+        return ""
+    return candidate

--- a/tests/test_generic_pipeline.py
+++ b/tests/test_generic_pipeline.py
@@ -282,6 +282,15 @@ class TestBuildNotificationLinks(unittest.TestCase):
         note = build_notification(item, "{trailer_link}")
         self.assertEqual(note.text, "")
 
+    def test_trailer_marker_renders_as_text(self) -> None:
+        # §IV: a non-http trailer_url (a miss/failure marker) must reach the user
+        # as visible text, not collapse to an empty line (#138). The generic
+        # renderer stays source-agnostic — it just escapes a non-http value.
+        item = self._item("Film", trailer_url="🎬 трейлер не найден")
+        note = build_notification(item, "{trailer_link}")
+        self.assertIn("🎬 трейлер не найден", note.text)
+        self.assertNotIn("<a", note.text)
+
     def test_kinozal_template(self) -> None:
         item = self._item(
             "Фильм / 2026 / WEB",

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -464,13 +464,14 @@ class TestPipelineCoverage(unittest.TestCase):
         self.assertRegex(joined, r"2 extracted.*0 new.*2 already-seen")
 
     def test_trailer_failure_still_notifies(self) -> None:
-        # Burst 10→50 raises YouTube-quota exhaustion risk. A trailer lookup
-        # failure must degrade visibly (§IV): the film still ships, sans
-        # trailer, with an ERROR logged — never a silent drop.
-        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="ERROR") as cm:
+        # A trailer lookup failure must degrade visibly (§IV): the film still
+        # ships, now carrying the error marker (#138) — with a WARNING logged,
+        # never a silent drop.
+        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="WARNING") as cm:
             storage, notifier = _run(youtube=_RaisingYoutube())
         self.assertEqual(len(notifier.sent), 2)
         self.assertTrue(any("trailer lookup failed" in line for line in cm.output))
+        self.assertTrue(all(_TRAILER_ERROR_MARKER in n.text for n in notifier.sent))
 
 
 class TestPipelineNotificationContent(unittest.TestCase):
@@ -488,7 +489,9 @@ class TestPipelineNotificationContent(unittest.TestCase):
         text = notifier.sent[0].text
         self.assertIn("youtube.com", text)
 
-    def test_no_trailing_newlines_when_trailer_empty(self) -> None:
+    def test_no_trailing_newlines_with_trailer_marker(self) -> None:
+        # _RaisingYoutube now yields the error marker (#138), not an empty
+        # trailer; the rendered message must still have no trailing newline.
         storage, notifier = _run(youtube=_RaisingYoutube())
         for notif in notifier.sent:
             self.assertFalse(notif.text.endswith("\n"), repr(notif.text))

--- a/tests/test_kinozal_pipeline.py
+++ b/tests/test_kinozal_pipeline.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import unittest
@@ -8,6 +9,8 @@ import kinozal_scraper.kinozal_pipeline as kp
 from kinozal_scraper.generic_pipeline import NormalizedItem, PipelineResult, extract_from_html
 from kinozal_scraper.kinozal_auth import KinozalLoginError
 from kinozal_scraper.kinozal_pipeline import (
+    _TRAILER_ERROR_MARKER,
+    _TRAILER_MISS_MARKER,
     _kinozal_title,
     _kinozal_urls,
     enrich_with_trailer,
@@ -16,6 +19,7 @@ from kinozal_scraper.kinozal_pipeline import (
 from kinozal_scraper.pipeline_config import load_sources_config
 from kinozal_scraper.sheets_storage import InMemoryStorage
 from kinozal_scraper.telegram_notifier import InMemoryNotifier
+from kinozal_scraper.text_utils import original_title
 from kinozal_scraper.text_utils import title_year_matches as _title_year_matches
 
 # ── minimal synthetic HTML matching kinozal_movies row_selector ──────────────
@@ -136,10 +140,51 @@ class TestEnrichWithTrailer(unittest.TestCase):
         self.assertIn("Film", trailer)
         self.assertNotIn("(2024)", trailer)
 
-    def test_exception_returns_empty_string(self) -> None:
+    def test_failure_returns_error_marker(self) -> None:
+        # §IV (#138): a lookup exception must surface a visible marker + WARNING,
+        # not a silent "". WARNING (not ERROR) is pinned via levelno.
         item = self._item("Some Film")
-        trailer = enrich_with_trailer(item, _RaisingYoutube())
-        self.assertEqual(trailer, "")
+        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="WARNING") as cm:
+            trailer = enrich_with_trailer(item, _RaisingYoutube())
+        self.assertEqual(trailer, _TRAILER_ERROR_MARKER)
+        self.assertEqual(cm.records[-1].levelno, logging.WARNING)
+
+    def test_miss_returns_miss_marker(self) -> None:
+        # §IV (#138): a clean miss (API OK, 0 results) surfaces a visible marker
+        # + INFO log (expected, not an anomaly), distinct from the error marker.
+        item = self._item("Some Film")
+        with self.assertLogs("kinozal_scraper.kinozal_pipeline", level="INFO") as cm:
+            trailer = enrich_with_trailer(item, _FilteringFakeYoutube([]))
+        self.assertEqual(trailer, _TRAILER_MISS_MARKER)
+        self.assertTrue(any(r.levelno == logging.INFO for r in cm.records))
+
+    def test_original_title_used_for_lookup(self) -> None:
+        youtube = _FakeYoutube()
+        item = self._item("Гнев / Man on Fire / 2026 / WEB-DLRip")
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_film, "Man on Fire")
+
+    def test_falls_back_to_clean_title_when_no_original(self) -> None:
+        youtube = _FakeYoutube()
+        item = self._item("Film One / 2024 / BDRip")  # 2nd segment is a year
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_film, "Film One")
+
+    def test_year_still_passed_with_original_title(self) -> None:
+        # SHOULD-FIX guard: switching the query to the original title must not
+        # drop the year= that feeds title_year_matches.
+        youtube = _FakeYoutube()
+        item = self._item("Гнев / Man on Fire / 2026 / WEB-DLRip")
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_year, 2026)
+
+    def test_original_segment_used_verbatim(self) -> None:
+        # Documents the non-strip decision: the original segment goes to YouTube
+        # as-is (parentheticals not stripped), unlike the clean-title fallback.
+        youtube = _FakeYoutube()
+        item = self._item("Русское / Man on Fire (uncut) / 2026 / WEB")
+        enrich_with_trailer(item, youtube)
+        self.assertEqual(youtube.last_film, "Man on Fire (uncut)")
 
     def test_year_extracted_from_dedupe_key_and_passed(self) -> None:
         youtube = _FakeYoutube()
@@ -191,6 +236,26 @@ class TestKinozalTitle(unittest.TestCase):
 
     def test_slash_without_spaces_not_split(self) -> None:
         self.assertEqual(_kinozal_title("ДБ (Videofilm/Int.)"), "ДБ (Videofilm/Int.)")
+
+
+# ── original_title ────────────────────────────────────────────────────────────
+
+
+class TestOriginalTitle(unittest.TestCase):
+    def test_extracts_second_segment(self) -> None:
+        raw = "Гнев (1 сезон: 1-7 серии из 7) / Man on Fire / 2026 / WEB-DLRip"
+        self.assertEqual(original_title(raw), "Man on Fire")
+
+    def test_year_second_segment_returns_empty(self) -> None:
+        # 'Title / Year / Format' — no distinct original title → '' (caller falls
+        # back to the clean RU title).
+        self.assertEqual(original_title("Film One / 2024 / BDRip"), "")
+
+    def test_no_separator_returns_empty(self) -> None:
+        self.assertEqual(original_title("Дюна"), "")
+
+    def test_slash_without_spaces_not_split(self) -> None:
+        self.assertEqual(original_title("ДБ (Videofilm/Int.)"), "")
 
 
 # ── _title_year_matches ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Первый PR трейлеров-epic (без зависимостей) — два root-cause фикса в `enrich_with_trailer`, до всякой AI-инфры:

1. **YouTube-запрос по оригинальному названию.** Новый чистый хелпер `original_title(raw)` в `text_utils.py` достаёт 2-й ` / `-сегмент raw-`@title` (`Man on Fire`); enrich шлёт его в YouTube вместо локализованного RU-названия (`Гнев`) — куда лучший матч трейлера. Фолбэк на clean RU-название, когда оригинала нет (2-й сегмент — год, либо нет разделителя).
2. **§IV: конец немому `return ""`.** Miss (API OK, 0 результатов) → `🎬 трейлер не найден` + INFO-лог; failure (exception) → `⚠️ трейлер: ошибка поиска` + WARNING-лог (`exc_info`). Оба видны в Telegram через рендер non-http `trailer_url` в shared `build_notification` (source-agnostic — не-kinozal источники не затронуты). Маркер не пишется в Sheets (`to_row` его не включает).

Совпало с issue `## Implementation outline`. Closes #138

## Test plan

- [x] `python scripts/ci_check.py` — green локально (562 passed, ruff/mypy/import-linter/pip-audit ×2 clean)
- [x] `tests/test_kinozal_pipeline.py::TestOriginalTitle` (4: второй сегмент, год→'', без разделителя→'', slash-без-пробелов→'')
- [x] `tests/test_kinozal_pipeline.py::TestEnrichWithTrailer` — original-used, fallback-to-clean, **year-still-passed** (регресс-guard), verbatim-original, miss→marker+INFO, failure→marker+WARNING (levelno-пин)
- [x] `tests/test_generic_pipeline.py::...::test_trailer_marker_renders_as_text` — non-http маркер виден, нет `<a`
- [x] обновлены существующие `test_trailer_failure_still_notifies` (ERROR→WARNING + маркер в тексте) и `test_no_trailing_newlines_with_trailer_marker`
- [ ] CI на PR — green

## Risk & Rollback

- **Blast-radius**: `enrich_with_trailer` вызывается только из kinozal-пайплайна (L532); `build_notification`-правка изолирована ветвлением по `trailer_url` (default `""` → старая пустая ветка), поэтому steam/github/soldout не затронуты. Sheets-дедуп не задет (маркер не в `to_row`).
- **Rollback**: чистый `git revert` — необратимых эффектов нет.
- **Мониторинг**: ближайший крон-ран `run-script.yml` — в Telegram у фильмов теперь либо кликабельный Trailer, либо видимый маркер `🎬`/`⚠️` вместо пустой строки.
